### PR TITLE
Implement on-the-fly compression

### DIFF
--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -83,7 +83,7 @@ def test_readwrite_live_compression_should_truncate():
     file_len = 4
     header = wkw.Header(np.uint8, block_type=wkw.Header.BLOCK_TYPE_LZ4, file_len=file_len)
     test_data = generate_test_data(header.voxel_type, SIZE128)
-    empty_data = np.zeros(SIZE128).astype(header.voxel_type)
+    ones_data = np.ones(SIZE128).astype(header.voxel_type)
 
     with wkw.Dataset.create('tests/tmp', header) as dataset:
         dataset.write(POSITION, test_data)
@@ -91,14 +91,14 @@ def test_readwrite_live_compression_should_truncate():
     random_compressed_size = path.getsize(path.join('tests/tmp', 'z0', 'y0', 'x0.wkw'))
 
     with wkw.Dataset.open('tests/tmp') as dataset:
-        dataset.write(POSITION, empty_data)
+        dataset.write(POSITION, ones_data)
 
     empty_compressed_size = path.getsize(path.join('tests/tmp', 'z0', 'y0', 'x0.wkw'))
 
     assert empty_compressed_size < random_compressed_size
 
     with wkw.Dataset.open('tests/tmp') as dataset:
-        assert np.all(dataset.read(POSITION, SIZE128) == empty_data)
+        assert np.all(dataset.read(POSITION, SIZE128) == ones_data)
 
 def test_compress():
     with wkw.Dataset.create('tests/tmp', wkw.Header(np.uint8)) as dataset:

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -64,6 +64,20 @@ def test_readwrite_live_compression_should_enforce_full_file_write():
             dataset.write(POSITION, test_data)
 
 
+def test_readwrite_live_compression_should_not_allow_inconsistent_writes():
+    SIZE129 = (129, 128, 128)
+    file_len = 4
+    header = wkw.Header(np.uint8, block_type=wkw.Header.BLOCK_TYPE_LZ4, file_len=file_len)
+    test_data = generate_test_data(header.voxel_type, SIZE129)
+    empty_data = np.zeros(SIZE129).astype(header.voxel_type)
+
+    with wkw.Dataset.create('tests/tmp', header) as dataset:
+        with pytest.raises(Exception):
+            dataset.write(POSITION, test_data)
+
+    with wkw.Dataset.open('tests/tmp') as dataset:
+        assert np.all(dataset.read(POSITION, SIZE129) == empty_data)
+
 def test_compress():
     with wkw.Dataset.create('tests/tmp', wkw.Header(np.uint8)) as dataset:
 

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -103,13 +103,6 @@ impl Dataset {
     }
 
     pub fn write_mat(&self, dst_pos: Vec3, mat: &Mat) -> Result<usize> {
-            // validate block type
-            match self.header.block_type {
-                BlockType::LZ4 => Err("Cannot write LZ4 blocks"),
-                BlockType::LZ4HC => Err("Cannot write LZ4HC blocks"),
-                _ => Ok(())
-            }?;
-
             // validate input matrix
             if mat.voxel_type != self.header.voxel_type {
                 return Err("Input matrix has invalid voxel type");

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -140,7 +140,7 @@ impl Dataset {
                         // offsets
                         let cur_src_pos = cur_box.min() - dst_pos;
                         let cur_dst_pos = cur_box.min() - cur_file_box.min();
-                        if self.header.block_type != BlockType::Raw {  
+                        if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {
                             if cur_box != cur_file_box {
                                 return Err("When writing compressed files, each file has to be \
                                     written as a whole. Please pad your data so that all cubes \

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -140,6 +140,13 @@ impl Dataset {
                         // offsets
                         let cur_src_pos = cur_box.min() - dst_pos;
                         let cur_dst_pos = cur_box.min() - cur_file_box.min();
+                        if self.header.block_type != BlockType::Raw {  
+                            if cur_box != cur_file_box {
+                                return Err("When writing compressed files, each file has to be \
+                                    written as a whole. Please pad your data so that all cubes \
+                                    are complete.");
+                            }
+                        };
 
                         let mut file = File::open_or_create(&cur_path, &self.header)?;
                         file.write_mat(cur_dst_pos, mat, cur_src_pos)?;

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -163,7 +163,6 @@ impl File {
                (cur_block_ids + 1) << block_len_log2)?;
             let cur_box = cur_block_box.intersect(dst_box);
 
-            // Todo: What about the following block in case of on-the-fly compression?
             if cur_box != cur_block_box {
                 // reuse existing data
                 self.seek_block(cur_block_idx)?;

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -175,18 +175,13 @@ impl File {
             // fill / modify buffer
             buf_mat.copy_from(cur_dst_pos, src_mat, cur_src_box)?;
 
-            if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {
-                // Since compressed blocks are written continuously in morton order, we mark the current position
-                // as the correct block position so that no seeking has to be done.
-                self.block_idx = Some(cur_block_idx);
-            }
             self.seek_block(cur_block_idx)?;
 
             // write data
             self.write_block(buf_mat.as_slice())?;
         }
 
-        if self.header.block_type != BlockType::Raw {
+        if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {
             // Update jump table
             self.write_header()?;
         }

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -34,7 +34,6 @@ impl File {
         let mut file = fs::File::open(path)
                                 .or(Err("Could not open WKW file"))?;
         let header = Header::read(&mut file)?;
-
         Ok(Self::new(file, header))
     }
 
@@ -153,7 +152,19 @@ impl File {
             self.header.voxel_type)?;
 
         // build Morton-order iterator
-        let iter = Iter::new(self.header.file_len_log2 as u32, dst_box_boxes)?;
+        let mut iter = Iter::new(self.header.file_len_log2 as u32, dst_box_boxes)?.peekable();
+
+        if self.header.block_type != BlockType::Raw {
+            // In case of enabled LZ4 compression, we seek to the first empty block
+            // and validate that no data should be written before that block. That way,
+            // we guarantee morton order.
+            let first_empty_block_idx = self.seek_to_first_empty_block()?;
+            if first_empty_block_idx > *iter.peek().unwrap() {
+                return Err("On-the-fly compression is enabled, but data is not written \
+                    in morton order. The first empty block appears after the block \
+                    which should be written to.");
+            }
+        }
 
         for cur_block_idx in iter {
             // box for current block
@@ -164,6 +175,7 @@ impl File {
                (cur_block_ids + 1) << block_len_log2)?;
             let cur_box = cur_block_box.intersect(dst_box);
 
+            // Todo: What about the following block in case of on-the-fly compression?
             if cur_box != cur_block_box {
                 // reuse existing data
                 self.seek_block(cur_block_idx)?;
@@ -176,9 +188,22 @@ impl File {
             // fill / modify buffer
             buf_mat.copy_from(cur_dst_pos, src_mat, cur_src_box)?;
 
+            if self.header.block_type == BlockType::Raw {
+                // Only seek if data is written in raw mode.
+                self.seek_block(cur_block_idx)?;
+            } else {
+                // Otherwise, compressed blocks are written continuously in morton order
+                // without additional seeking.
+                self.block_idx = Some(cur_block_idx);
+            }
+
             // write data
-            self.seek_block(cur_block_idx)?;
             self.write_block(buf_mat.as_slice())?;
+        }
+
+        if self.header.block_type != BlockType::Raw {
+            // Update jump table
+            self.write_header()?;
         }
 
         Ok(1 as usize)
@@ -312,6 +337,13 @@ impl File {
         let block_idx = self.block_idx.unwrap();
         let jump_table = &mut *self.header.jump_table.as_mut().unwrap();
         jump_table[block_idx as usize] = jump_entry;
+        if block_idx > 0 {
+            // Update the previous jump table entry since the difference
+            // of adjacent values has to equal the size of the written block.
+            // This is necessary for blocks written with on-the-fly compression,
+            // as the jump_table might be sparse in such cases.
+            jump_table[block_idx as usize - 1] = jump_entry - len_lz4 as u64;
+        }
 
         Ok(len_lz4)
     }
@@ -351,6 +383,30 @@ impl File {
             Ok(_) => {
                 self.block_idx = Some(block_idx);
                 Ok(block_idx)
+            }
+        }
+    }
+
+    fn seek_to_first_empty_block(&mut self) -> Result<u64> {
+        let jump_table = &mut *self.header.jump_table.as_mut().unwrap();
+        let mut max_offset = self.header.data_offset;
+
+        let mut used_block_idx = 0;
+        for (current_idx, entry) in jump_table.iter().enumerate() {
+            if 0 < *entry && *entry < max_offset {
+                panic!("Jump table is invalid. Values are not increasing monotonically.");
+            }
+            if *entry > max_offset {
+                max_offset = *entry;
+                used_block_idx = current_idx;
+            }
+        }
+
+        // seek to byte offset
+        match self.file.seek(SeekFrom::Start(max_offset)) {
+            Err(_) => Err("Could not seek block"),
+            Ok(_) => {
+                Ok(used_block_idx as u64)
             }
         }
     }


### PR DESCRIPTION
Also see #20.

In discussion with @normanrz, we decided that unbuffered "live compression" for write calls would already be a very valuable feature. This means that blocks are compressed and written directly "as they come" in morton order. Write-calls at random positions are forbidden, for that reason. Additionally, this means that we don't change the semantics of the `write` call, since adding a buffer would delay the "actual writing" to a later point in time.

The API interface didn't change. However, it is now possible to `create` a dataset with a LZ4 header and make `write` calls (previously, this produced an "unsupported" message). Have a look at the new tests to see the usage.

@amotta My rust experience is quite limited. So, feel free to give feedback :)