### PR TITLE
fix c signature for open_dataset

### DIFF
--- a/c/include/wkw.h
+++ b/c/include/wkw.h
@@ -12,7 +12,7 @@ struct header {
 
 typedef struct dataset dataset_t;
 
-void * dataset_open(const char * root);
+dataset_t * dataset_open(const char * root);
 void   dataset_close(const dataset_t * handle);
 int    dataset_read(const dataset_t * handle, const uint32_t * bbox, void * data);
 int    dataset_write(const dataset_t * handle, const uint32_t * bbox, const void * data);


### PR DESCRIPTION
Hi Alessandro,
I noticed (or rather my C++ compiler noticed) that the `dataset_open` function returns a `void *`, while all other functions require `dataset_t *` pointers as arguments. I changed the signature accordingly. Just want to make sure this breaks nothing on your side.