### PR TITLE
Update README for Python package

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,6 @@
 # webKNOSSOS Wrapper for Python
 This directory contains the code for creating, reading, writing, and
-compressing webKNOSSOS wrapper datasets from Python. **WARNING:** This
-library is experimental. It is **not ready for production**.
+compressing webKnossos wrapper (WKW) datasets from Python.
 
 ## Example
 ```python

--- a/python/README.md
+++ b/python/README.md
@@ -1,8 +1,16 @@
-# webKNOSSOS Wrapper for Python
+# webKnossos Wrapper (WKW) for Python
 This directory contains the code for creating, reading, writing, and
 compressing webKnossos wrapper (WKW) datasets from Python.
 
 ## Example
+First, let's install the `wkw` package from the Python Package Index
+(PyPI) by running
+```bash
+$ pip install wkw
+```
+
+The `wkw` package may then be imported and used as follows:
+
 ```python
 import wkw
 import numpy as np
@@ -17,7 +25,7 @@ dataset = wkw.Dataset.open('./wkw')
 data = dataset.read([0, 0, 0], [128, 128, 128])
 ```
 
-## How to build the library
+## How to build this package
 To build and install this Python package, just run
 ```bash
 $ python setup.py install


### PR DESCRIPTION
Changes:
* The Python package has been used in production for a while now. So, let's remove the warning.
* Make sure that interested users install via `pip` instead of building from source