### PR TITLE
Bugfix: wkwBoundingBox

### DIFF
--- a/matlab/wkwBoundingBox.m
+++ b/matlab/wkwBoundingBox.m
@@ -27,7 +27,14 @@ function box = wkwBoundingBox(wkwDir)
         fullfile(f.folder, f.name), ...
         wkwFiles, 'UniformOutput', false);
     
-    pattern = ['z(\d+)', filesep, 'y(\d+)', filesep, 'x(\d+)'];
+    escChar = '';
+    if strcmp(filesep, '\')
+        escChar = '\';
+    end
+    pattern = [...
+        'z(\d+)', filesep, escChar, ...
+        'y(\d+)', filesep, escChar, ...
+        'x(\d+)'];
     coords = regexp(wkwFiles, pattern, 'tokens', 'once');
     
     coords = flip(cat(1, coords{:}), 2);


### PR DESCRIPTION
wkwBoundingBox matches directory names using regexp in combination with filesep
under Windows filesep is '\' which is a special character for regexp that needs to be escaped by another '\'