### PR TITLE
Improve write performance

### DIFF
--- a/c/include/wkw.h
+++ b/c/include/wkw.h
@@ -15,7 +15,7 @@ typedef struct dataset dataset_t;
 dataset_t * dataset_open(const char * root);
 void   dataset_close(const dataset_t * handle);
 int    dataset_read(const dataset_t * handle, const uint32_t * bbox, void * data);
-int    dataset_write(const dataset_t * handle, const uint32_t * bbox, const void * data);
+int    dataset_write(const dataset_t * handle, const uint32_t * bbox, const void * data, bool is_fortran_order);
 void   dataset_get_header(const dataset_t * handle, struct header * header);
 void * dataset_create(const char * root, const struct header * header);
 int    file_compress(const char * src_path, const char * dst_path);

--- a/c/include/wkw.h
+++ b/c/include/wkw.h
@@ -15,7 +15,7 @@ typedef struct dataset dataset_t;
 dataset_t * dataset_open(const char * root);
 void   dataset_close(const dataset_t * handle);
 int    dataset_read(const dataset_t * handle, const uint32_t * bbox, void * data);
-int    dataset_write(const dataset_t * handle, const uint32_t * bbox, const void * data, bool is_fortran_order);
+int    dataset_write(const dataset_t * handle, const uint32_t * bbox, const void * data, bool data_in_c_order);
 void   dataset_get_header(const dataset_t * handle, struct header * header);
 void * dataset_create(const char * root, const struct header * header);
 int    file_compress(const char * src_path, const char * dst_path);

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -202,7 +202,7 @@ fn c_data_to_mat<'a>(
     dataset: &wkwrap::Dataset,
     shape: &'a wkwrap::Vec3,
     data_ptr: *const c_void,
-    is_fortran_order: bool,
+    data_in_c_order: bool,
 ) -> wkwrap::Mat<'a> {
     let voxel_type = dataset.header().voxel_type;
     let voxel_size = dataset.header().voxel_size as usize;
@@ -210,7 +210,7 @@ fn c_data_to_mat<'a>(
     let data_len = shape.product() as usize * voxel_size;
     let data = unsafe { std::slice::from_raw_parts_mut(data_ptr as *mut u8, data_len) };
 
-    wkwrap::Mat::new(data, *shape, voxel_size, voxel_type, is_fortran_order).unwrap()
+    wkwrap::Mat::new(data, *shape, voxel_size, voxel_type, data_in_c_order).unwrap()
 }
 
 #[no_mangle]
@@ -226,7 +226,7 @@ pub extern "C" fn dataset_read(
     let dataset = unsafe { Box::from_raw(dataset_ptr as *mut wkwrap::Dataset) };
     let (off, shape) = c_bbox_to_off_and_shape(bbox_ptr);
 
-    let mut mat = c_data_to_mat(&dataset, &shape, data_ptr, true);
+    let mut mat = c_data_to_mat(&dataset, &shape, data_ptr, false);
     let ret = dataset.read_mat(off, &mut mat);
     std::mem::forget(dataset);
     check_return(ret)
@@ -237,7 +237,7 @@ pub extern "C" fn dataset_write(
     dataset_ptr: *const Dataset,
     bbox_ptr: *const c_ulong,
     data_ptr: *const c_void,
-    is_fortran_order: bool,
+    data_in_c_order: bool,
 ) -> c_int {
     assert!(!dataset_ptr.is_null());
     assert!(!bbox_ptr.is_null());
@@ -247,7 +247,7 @@ pub extern "C" fn dataset_write(
 
     let (off, shape) = c_bbox_to_off_and_shape(bbox_ptr);
 
-    let mat = c_data_to_mat(&dataset, &shape, data_ptr, is_fortran_order);
+    let mat = c_data_to_mat(&dataset, &shape, data_ptr, data_in_c_order);
     let ret = dataset.write_mat(off, &mat);
     std::mem::forget(dataset);
     check_return(ret)

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -245,15 +245,6 @@ pub extern "C" fn dataset_write(
 
     let dataset = unsafe { Box::from_raw(dataset_ptr as *mut wkwrap::Dataset) };
 
-    // dataset.write cannot cope with multichannel data if row-major order.
-    {
-        let header = dataset.header();
-        let num_channels = header.voxel_type.size() / header.voxel_size as usize;
-        if num_channels > 1 {
-            assert!(is_fortran_order);
-        }
-    }
-
     let (off, shape) = c_bbox_to_off_and_shape(bbox_ptr);
 
     let mat = c_data_to_mat(&dataset, &shape, data_ptr, is_fortran_order);

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -5,7 +5,7 @@ use wkwrap as wkw;
 extern crate lazy_static;
 
 use std::ffi::{CStr, CString};
-use std::os::raw::{c_int, c_char, c_void, c_ulong};
+use std::os::raw::{c_char, c_int, c_ulong, c_void};
 
 use std::path::Path;
 use std::sync::Mutex;
@@ -19,13 +19,13 @@ pub struct Header {
     pub file_len: u8,
     pub block_type: u8,
     pub voxel_type: u8,
-    pub voxel_size: u8
+    pub voxel_size: u8,
 }
 
 fn as_log2(i: u8) -> Result<u8, &'static str> {
     match i & (i - 1) == 0 {
         true => Ok(i.trailing_zeros() as u8),
-        false => Err("Input must be a power of two")
+        false => Err("Input must be a power of two"),
     }
 }
 
@@ -38,21 +38,21 @@ fn from_header(header_ptr: *const Header) -> Result<wkw::Header, &'static str> {
         1 => wkw::BlockType::Raw,
         2 => wkw::BlockType::LZ4,
         3 => wkw::BlockType::LZ4HC,
-        _ => return Err("Block type is invalid")
+        _ => return Err("Block type is invalid"),
     };
 
     let voxel_type = match c_header.voxel_type {
-        1  => wkw::VoxelType::U8,
-        2  => wkw::VoxelType::U16,
-        3  => wkw::VoxelType::U32,
-        4  => wkw::VoxelType::U64,
-        5  => wkw::VoxelType::F32,
-        6  => wkw::VoxelType::F64,
-        7  => wkw::VoxelType::I8,
-        8  => wkw::VoxelType::I16,
-        9  => wkw::VoxelType::I32,
+        1 => wkw::VoxelType::U8,
+        2 => wkw::VoxelType::U16,
+        3 => wkw::VoxelType::U32,
+        4 => wkw::VoxelType::U64,
+        5 => wkw::VoxelType::F32,
+        6 => wkw::VoxelType::F64,
+        7 => wkw::VoxelType::I8,
+        8 => wkw::VoxelType::I16,
+        9 => wkw::VoxelType::I32,
         10 => wkw::VoxelType::I64,
-        _  => return Err("Voxel type is invalid")
+        _ => return Err("Voxel type is invalid"),
     };
 
     let block_len_log2 = as_log2(c_header.block_len)?;
@@ -66,7 +66,7 @@ fn from_header(header_ptr: *const Header) -> Result<wkw::Header, &'static str> {
         voxel_type: voxel_type,
         voxel_size: c_header.voxel_size,
         data_offset: 0,
-        jump_table: None
+        jump_table: None,
     })
 }
 
@@ -81,12 +81,12 @@ fn check_return<T>(ret: Result<T, &str>) -> c_int {
 }
 
 lazy_static! {
-    static ref LAST_ERR_MSG: Mutex<Box<CStr>> = Mutex::new(
-        CString::new("".as_bytes()).unwrap().into_boxed_c_str());
+    static ref LAST_ERR_MSG: Mutex<Box<CStr>> =
+        Mutex::new(CString::new("".as_bytes()).unwrap().into_boxed_c_str());
 }
 
 #[no_mangle]
-pub extern fn get_last_error_msg() -> *const c_char {
+pub extern "C" fn get_last_error_msg() -> *const c_char {
     LAST_ERR_MSG.lock().unwrap().as_ptr()
 }
 
@@ -96,7 +96,7 @@ fn set_last_error_msg(msg: &str) {
 }
 
 #[no_mangle]
-pub extern fn dataset_open(root_ptr: *const c_char) -> *const Dataset {
+pub extern "C" fn dataset_open(root_ptr: *const c_char) -> *const Dataset {
     assert!(!root_ptr.is_null());
     let root_str = unsafe { CStr::from_ptr(root_ptr) }.to_str().unwrap();
     let root_path = Path::new(root_str);
@@ -105,7 +105,7 @@ pub extern fn dataset_open(root_ptr: *const c_char) -> *const Dataset {
         Ok(dataset) => {
             let dataset_ptr = Box::from(dataset);
             unsafe { std::mem::transmute(dataset_ptr) }
-        },
+        }
         Err(msg) => {
             set_last_error_msg(msg);
             std::ptr::null::<Dataset>()
@@ -114,7 +114,7 @@ pub extern fn dataset_open(root_ptr: *const c_char) -> *const Dataset {
 }
 
 #[no_mangle]
-pub extern fn dataset_close(dataset_ptr: *const Dataset) {
+pub extern "C" fn dataset_close(dataset_ptr: *const Dataset) {
     assert!(!dataset_ptr.is_null());
 
     #[allow(unused_variables)]
@@ -125,7 +125,7 @@ pub extern fn dataset_close(dataset_ptr: *const Dataset) {
 }
 
 #[no_mangle]
-pub extern fn dataset_get_header(dataset_ptr: *const Dataset, header_ptr: *mut Header) {
+pub extern "C" fn dataset_get_header(dataset_ptr: *const Dataset, header_ptr: *mut Header) {
     assert!(!dataset_ptr.is_null());
     assert!(!header_ptr.is_null());
 
@@ -145,10 +145,13 @@ pub extern fn dataset_get_header(dataset_ptr: *const Dataset, header_ptr: *mut H
 }
 
 #[no_mangle]
-pub extern fn dataset_create(root_ptr: *const c_char, header_ptr: *const Header) -> *const Dataset {
+pub extern "C" fn dataset_create(
+    root_ptr: *const c_char,
+    header_ptr: *const Header,
+) -> *const Dataset {
     assert!(!header_ptr.is_null());
     assert!(!root_ptr.is_null());
-    
+
     let root_str = unsafe { CStr::from_ptr(root_ptr) }.to_str().unwrap();
     let root_path = Path::new(root_str);
 
@@ -156,7 +159,7 @@ pub extern fn dataset_create(root_ptr: *const c_char, header_ptr: *const Header)
         Ok(dataset) => {
             let dataset_ptr = Box::from(dataset);
             unsafe { std::mem::transmute(dataset_ptr) }
-        },
+        }
         Err(msg) => {
             set_last_error_msg(msg);
             std::ptr::null::<Dataset>()
@@ -165,7 +168,7 @@ pub extern fn dataset_create(root_ptr: *const c_char, header_ptr: *const Header)
 }
 
 #[no_mangle]
-pub extern fn file_compress(src_path_ptr: *const c_char, dst_path_ptr: *const c_char) -> c_int {
+pub extern "C" fn file_compress(src_path_ptr: *const c_char, dst_path_ptr: *const c_char) -> c_int {
     assert!(!src_path_ptr.is_null());
     assert!(!dst_path_ptr.is_null());
 
@@ -178,20 +181,18 @@ pub extern fn file_compress(src_path_ptr: *const c_char, dst_path_ptr: *const c_
 }
 
 fn c_bbox_to_off_and_shape(bbox_ptr: *const c_ulong) -> (wkwrap::Vec3, wkwrap::Vec3) {
-    let bbox = unsafe {
-        std::slice::from_raw_parts(bbox_ptr as *const u32, 6)
-    };
+    let bbox = unsafe { std::slice::from_raw_parts(bbox_ptr as *const u32, 6) };
 
     let off = wkwrap::Vec3 {
         x: bbox[0],
         y: bbox[1],
-        z: bbox[2]
+        z: bbox[2],
     };
 
     let shape = wkwrap::Vec3 {
         x: bbox[3] - bbox[0],
         y: bbox[4] - bbox[1],
-        z: bbox[5] - bbox[2]
+        z: bbox[5] - bbox[2],
     };
 
     (off, shape)
@@ -201,7 +202,7 @@ fn c_data_to_mat<'a>(
     dataset: &wkwrap::Dataset,
     shape: &'a wkwrap::Vec3,
     data_ptr: *const c_void,
-    is_fortran_order: bool
+    is_fortran_order: bool,
 ) -> wkwrap::Mat<'a> {
     let voxel_type = dataset.header().voxel_type;
     let voxel_size = dataset.header().voxel_size as usize;
@@ -213,10 +214,10 @@ fn c_data_to_mat<'a>(
 }
 
 #[no_mangle]
-pub extern fn dataset_read(
+pub extern "C" fn dataset_read(
     dataset_ptr: *const Dataset,
     bbox_ptr: *const c_ulong,
-    data_ptr: *mut c_void
+    data_ptr: *mut c_void,
 ) -> c_int {
     assert!(!dataset_ptr.is_null());
     assert!(!bbox_ptr.is_null());
@@ -232,17 +233,27 @@ pub extern fn dataset_read(
 }
 
 #[no_mangle]
-pub extern fn dataset_write(
+pub extern "C" fn dataset_write(
     dataset_ptr: *const Dataset,
     bbox_ptr: *const c_ulong,
     data_ptr: *const c_void,
-    is_fortran_order: bool
+    is_fortran_order: bool,
 ) -> c_int {
     assert!(!dataset_ptr.is_null());
     assert!(!bbox_ptr.is_null());
     assert!(!data_ptr.is_null());
 
     let dataset = unsafe { Box::from_raw(dataset_ptr as *mut wkwrap::Dataset) };
+
+    // dataset.write cannot cope with multichannel data if row-major order.
+    {
+        let header = dataset.header();
+        let num_channels = header.voxel_type.size() / header.voxel_size as usize;
+        if num_channels > 1 {
+            assert!(is_fortran_order);
+        }
+    }
+
     let (off, shape) = c_bbox_to_off_and_shape(bbox_ptr);
 
     let mat = c_data_to_mat(&dataset, &shape, data_ptr, is_fortran_order);
@@ -250,4 +261,3 @@ pub extern fn dataset_write(
     std::mem::forget(dataset);
     check_return(ret)
 }
-

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -164,31 +164,31 @@ def test_compress():
 
 
 def test_row_major_order():
-    SIZE128 = (4, 5, 6)
-    data = generate_test_data(np.uint8, SIZE128)
+    data_shape = (4, 5, 6)
+    data = generate_test_data(np.uint8, data_shape)
     print(data)
     with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
         dataset.write((0, 0, 0), data)
-        read_data = dataset.read((0, 0, 0), SIZE128)
+        read_data = dataset.read((0, 0, 0), data_shape)
 
     assert np.all(data == read_data)
 
     with wkw.Dataset.create("tests/tmp2", wkw.Header(np.uint8)) as dataset:
         fortran_data = np.asfortranarray(data)
         dataset.write((0, 0, 0), fortran_data)
-        fortran_read_data = dataset.read((0, 0, 0), SIZE128)
+        fortran_read_data = dataset.read((0, 0, 0), data_shape)
 
     assert np.all(fortran_read_data == read_data)
     assert np.all(fortran_read_data == fortran_data)
 
 
-def test_row_major_order_other_shape():
-    SIZE128 = (17, 1, 4)
-    data = generate_test_data(np.uint8, SIZE128)
+def test_row_major_order_with_offset():
+    data_shape = (17, 1, 4)
+    data = generate_test_data(np.uint8, data_shape)
     print(data)
     with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
         dataset.write((15, 2, 0), data)
-        read_data = dataset.read((15, 2, 0), SIZE128)
+        read_data = dataset.read((15, 2, 0), data_shape)
 
     assert np.all(data == read_data)
 

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -190,6 +190,7 @@ def test_row_major_order_with_offset():
 
     assert np.all(data == read_data)
 
+
 def test_row_major_order_with_different_voxel_size():
     data_shape = (4, 3, 9)
     data = generate_test_data(np.uint16, data_shape)
@@ -203,7 +204,9 @@ def test_row_major_order_with_different_voxel_size():
 def test_row_major_order_with_channels():
     data_shape = (2, 4, 3, 9)
     data = generate_test_data(np.uint8, data_shape)
-    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8, num_channels=2)) as dataset:
+    with wkw.Dataset.create(
+        "tests/tmp", wkw.Header(np.uint8, num_channels=2)
+    ) as dataset:
         dataset.write((3, 1, 0), data)
         read_data = dataset.read((3, 1, 0), data_shape[1:])
 
@@ -213,7 +216,9 @@ def test_row_major_order_with_channels():
 def test_row_major_order_with_channels_and_different_voxel_size():
     data_shape = (2, 4, 3, 9)
     data = generate_test_data(np.uint16, data_shape)
-    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint16, num_channels=2)) as dataset:
+    with wkw.Dataset.create(
+        "tests/tmp", wkw.Header(np.uint16, num_channels=2)
+    ) as dataset:
         dataset.write((3, 1, 0), data)
         read_data = dataset.read((3, 1, 0), data_shape[1:])
 
@@ -223,7 +228,9 @@ def test_row_major_order_with_channels_and_different_voxel_size():
 def test_column_major_order_with_channels_and_different_voxel_size():
     data_shape = (2, 4, 3, 9)
     data = generate_test_data(np.uint16, data_shape, order="F")
-    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint16, num_channels=2)) as dataset:
+    with wkw.Dataset.create(
+        "tests/tmp", wkw.Header(np.uint16, num_channels=2)
+    ) as dataset:
         dataset.write((3, 1, 0), data)
         read_data = dataset.read((3, 1, 0), data_shape[1:])
 
@@ -242,7 +249,10 @@ def test_view_on_np_array():
 
 
 def generate_test_data(dtype, size=SIZE, order="C"):
-    return np.array(np.random.uniform(np.iinfo(dtype).min, np.iinfo(dtype).max, size).astype(dtype), order=order)
+    return np.array(
+        np.random.uniform(np.iinfo(dtype).min, np.iinfo(dtype).max, size).astype(dtype),
+        order=order,
+    )
 
 
 def try_rmtree(dir):

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -162,6 +162,25 @@ def test_compress():
             )
             assert np.all(dataset2.read(POSITION, SIZE) == test_data)
 
+def test_row_major_order():
+    SIZE128 = (4, 5, 1)
+    data = generate_test_data(np.uint8, SIZE128)
+    print(data)
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
+        dataset.write((0, 0, 0), data)
+        read_data = dataset.read((0, 0, 0), SIZE128)
+
+    assert np.all(data == read_data)
+
+    with wkw.Dataset.create("tests/tmp2", wkw.Header(np.uint8)) as dataset:
+        fortran_data = np.asfortranarray(data)
+        dataset.write((0, 0, 0), fortran_data)
+        fortran_read_data = dataset.read((0, 0, 0), SIZE128)
+
+    assert np.all(fortran_read_data == read_data)
+    assert np.all(fortran_read_data == fortran_data)
+
+
 
 def generate_test_data(dtype, size=SIZE):
     return np.random.uniform(0, 255, size).astype(dtype)

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -210,8 +210,39 @@ def test_row_major_order_with_channels():
     assert np.all(data == read_data)
 
 
-def generate_test_data(dtype, size=SIZE):
-    return np.random.uniform(0, 255, size).astype(dtype)
+def test_row_major_order_with_channels_and_different_voxel_size():
+    data_shape = (2, 4, 3, 9)
+    data = generate_test_data(np.uint16, data_shape)
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint16, num_channels=2)) as dataset:
+        dataset.write((3, 1, 0), data)
+        read_data = dataset.read((3, 1, 0), data_shape[1:])
+
+    assert np.all(data == read_data)
+
+
+def test_column_major_order_with_channels_and_different_voxel_size():
+    data_shape = (2, 4, 3, 9)
+    data = generate_test_data(np.uint16, data_shape, order="F")
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint16, num_channels=2)) as dataset:
+        dataset.write((3, 1, 0), data)
+        read_data = dataset.read((3, 1, 0), data_shape[1:])
+
+    assert np.all(data == read_data)
+
+
+def test_view_on_np_array():
+    data_shape = (4, 4, 9)
+    data = generate_test_data(np.uint16, data_shape)
+    data = data[:, ::2]
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint16)) as dataset:
+        dataset.write((3, 1, 0), data)
+        read_data = dataset.read((3, 1, 0), data.shape)
+
+    assert np.all(data == read_data)
+
+
+def generate_test_data(dtype, size=SIZE, order="C"):
+    return np.array(np.random.uniform(np.iinfo(dtype).min, np.iinfo(dtype).max, size).astype(dtype), order=order)
 
 
 def try_rmtree(dir):

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -166,7 +166,6 @@ def test_compress():
 def test_row_major_order():
     data_shape = (4, 5, 6)
     data = generate_test_data(np.uint8, data_shape)
-    print(data)
     with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
         dataset.write((0, 0, 0), data)
         read_data = dataset.read((0, 0, 0), data_shape)
@@ -185,10 +184,28 @@ def test_row_major_order():
 def test_row_major_order_with_offset():
     data_shape = (17, 1, 4)
     data = generate_test_data(np.uint8, data_shape)
-    print(data)
     with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
         dataset.write((15, 2, 0), data)
         read_data = dataset.read((15, 2, 0), data_shape)
+
+    assert np.all(data == read_data)
+
+def test_row_major_order_with_different_voxel_size():
+    data_shape = (4, 3, 9)
+    data = generate_test_data(np.uint16, data_shape)
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint16)) as dataset:
+        dataset.write((3, 1, 0), data)
+        read_data = dataset.read((3, 1, 0), data_shape)
+
+    assert np.all(data == read_data)
+
+
+def test_row_major_order_with_channels():
+    data_shape = (2, 4, 3, 9)
+    data = generate_test_data(np.uint8, data_shape)
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8, num_channels=2)) as dataset:
+        dataset.write((3, 1, 0), data)
+        read_data = dataset.read((3, 1, 0), data_shape[1:])
 
     assert np.all(data == read_data)
 

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -162,8 +162,9 @@ def test_compress():
             )
             assert np.all(dataset2.read(POSITION, SIZE) == test_data)
 
+
 def test_row_major_order():
-    SIZE128 = (4, 5, 1)
+    SIZE128 = (4, 5, 6)
     data = generate_test_data(np.uint8, SIZE128)
     print(data)
     with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
@@ -180,6 +181,16 @@ def test_row_major_order():
     assert np.all(fortran_read_data == read_data)
     assert np.all(fortran_read_data == fortran_data)
 
+
+def test_row_major_order_other_shape():
+    SIZE128 = (17, 1, 4)
+    data = generate_test_data(np.uint8, SIZE128)
+    print(data)
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
+        dataset.write((15, 2, 0), data)
+        read_data = dataset.read((15, 2, 0), SIZE128)
+
+    assert np.all(data == read_data)
 
 
 def generate_test_data(dtype, size=SIZE):

--- a/python/wkw/wkw.py
+++ b/python/wkw/wkw.py
@@ -206,7 +206,9 @@ class Dataset:
 
         is_fortran_order = data.flags["F_CONTIGUOUS"]
         data_ptr = ffi.cast("void *", data.ctypes.data)
-        _check_wkw(libwkw.dataset_write(self.handle, box_ptr, data_ptr, is_fortran_order))
+        _check_wkw(
+            libwkw.dataset_write(self.handle, box_ptr, data_ptr, is_fortran_order)
+        )
 
     def compress(self, dst_path: str, compress_files: bool = False):
         header = deepcopy(self.header)

--- a/python/wkw/wkw.py
+++ b/python/wkw/wkw.py
@@ -201,7 +201,6 @@ class Dataset:
                 "Data elements must be of type {}".format(self.header.voxel_type)
             )
 
-
         def is_contiguous(data):
             return data.flags["F_CONTIGUOUS"] or data.flags["C_CONTIGUOUS"]
 
@@ -213,7 +212,7 @@ class Dataset:
         box_ptr = ffi.cast("uint32_t *", box.ctypes.data)
 
         assert is_contiguous(data), "Input data is not contiguous"
-        
+
         data_in_c_order = data.flags["C_CONTIGUOUS"]
         data_ptr = ffi.cast("void *", data.ctypes.data)
         _check_wkw(

--- a/python/wkw/wkw.py
+++ b/python/wkw/wkw.py
@@ -201,6 +201,11 @@ class Dataset:
                 "Data elements must be of type {}".format(self.header.voxel_type)
             )
 
+        is_contiguous = (data.flags["F_CONTIGUOUS"] or data.flags["C_CONTIGUOUS"])
+
+        if self.header.num_channels != 1 or not is_contiguous:
+            data = np.asfortranarray(data)
+
         box = _build_box(off, data.shape[-3:])
         box_ptr = ffi.cast("uint32_t *", box.ctypes.data)
 

--- a/python/wkw/wkw.py
+++ b/python/wkw/wkw.py
@@ -201,7 +201,7 @@ class Dataset:
                 "Data elements must be of type {}".format(self.header.voxel_type)
             )
 
-        is_contiguous = (data.flags["F_CONTIGUOUS"] or data.flags["C_CONTIGUOUS"])
+        is_contiguous = data.flags["F_CONTIGUOUS"] or data.flags["C_CONTIGUOUS"]
 
         if self.header.num_channels != 1 or not is_contiguous:
             data = np.asfortranarray(data)

--- a/python/wkw/wkw.py
+++ b/python/wkw/wkw.py
@@ -203,6 +203,7 @@ class Dataset:
 
         is_contiguous = data.flags["F_CONTIGUOUS"] or data.flags["C_CONTIGUOUS"]
 
+        # the row-major handling of the rust lib cannot handle num_channels > 1
         if self.header.num_channels != 1 or not is_contiguous:
             data = np.asfortranarray(data)
 

--- a/python/wkw/wkw.py
+++ b/python/wkw/wkw.py
@@ -204,9 +204,9 @@ class Dataset:
         box = _build_box(off, data.shape[-3:])
         box_ptr = ffi.cast("uint32_t *", box.ctypes.data)
 
-        data = np.asfortranarray(data)
+        is_fortran_order = data.flags["F_CONTIGUOUS"]
         data_ptr = ffi.cast("void *", data.ctypes.data)
-        _check_wkw(libwkw.dataset_write(self.handle, box_ptr, data_ptr))
+        _check_wkw(libwkw.dataset_write(self.handle, box_ptr, data_ptr, is_fortran_order))
 
     def compress(self, dst_path: str, compress_files: bool = False):
         header = deepcopy(self.header)

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -117,6 +117,11 @@ impl Dataset {
             return Err("Input matrix has invalid voxel size");
         }
 
+        let num_channels = self.header.voxel_type.size() / self.header.voxel_size as usize;
+        if num_channels > 1 && mat.get_is_fortran_order() {
+            return Err("Cannot write multichannel data if data is in row-major order.");
+        }
+
         let file_len_vx_log2 = self.header.file_len_vx_log2() as u32;
         if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {
             let file_len_vec = Vec3::from(1 << file_len_vx_log2);

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -1,11 +1,11 @@
-use ::{BlockType, File, Header, Result, Vec3, Box3, Mat};
-use std::path::{Path, PathBuf};
 use std::fs;
+use std::path::{Path, PathBuf};
+use {BlockType, Box3, File, Header, Mat, Result, Vec3};
 
 #[derive(Debug)]
 pub struct Dataset {
     root: PathBuf,
-    header: Header
+    header: Header,
 }
 
 static HEADER_FILE_NAME: &'static str = "header.wkw";
@@ -13,7 +13,7 @@ static HEADER_FILE_NAME: &'static str = "header.wkw";
 impl Dataset {
     pub fn new(root: &Path) -> Result<Dataset> {
         if !root.is_dir() {
-            return Err("Dataset root is not a directory")
+            return Err("Dataset root is not a directory");
         }
 
         // read required header file
@@ -21,14 +21,13 @@ impl Dataset {
 
         Ok(Dataset {
             root: root.to_owned(),
-            header: header
+            header: header,
         })
     }
 
     pub fn create(root: &Path, mut header: Header) -> Result<Dataset> {
         // create directory hierarchy
-        fs::create_dir_all(root)
-           .or(Err("Could not create dataset directory"))?;
+        fs::create_dir_all(root).or(Err("Could not create dataset directory"))?;
 
         // create header file
         Self::create_header_file(root, &mut header)?;
@@ -53,13 +52,14 @@ impl Dataset {
         }
 
         // create header file
-        let mut file = fs::File::create(header_path)
-                                .or(Err("Could not create header file"))?;
+        let mut file = fs::File::create(header_path).or(Err("Could not create header file"))?;
 
         header.write(&mut file)
     }
 
-    pub fn header(&self) -> &Header { &self.header }
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
 
     pub fn read_mat(&self, src_pos: Vec3, mat: &mut Mat) -> Result<usize> {
         let bbox = Box3::from(mat.shape) + src_pos;
@@ -68,7 +68,7 @@ impl Dataset {
         // find files to load
         let bbox_files = Box3::new(
             bbox.min() >> file_len_vx_log2,
-          ((bbox.max() - 1) >> file_len_vx_log2) + 1
+            ((bbox.max() - 1) >> file_len_vx_log2) + 1,
         )?;
 
         for cur_z in bbox_files.min().z..bbox_files.max().z {
@@ -81,10 +81,15 @@ impl Dataset {
                     cur_path.push(format!("x{}.wkw", cur_x));
 
                     // bounding box
-                    let cur_file_ids = Vec3 { x: cur_x, y: cur_y, z: cur_z };
+                    let cur_file_ids = Vec3 {
+                        x: cur_x,
+                        y: cur_y,
+                        z: cur_z,
+                    };
                     let cur_file_box = Box3::new(
                         cur_file_ids << file_len_vx_log2,
-                       (cur_file_ids + 1) << file_len_vx_log2)?;
+                        (cur_file_ids + 1) << file_len_vx_log2,
+                    )?;
                     let cur_box = cur_file_box.intersect(bbox);
 
                     // offsets
@@ -103,62 +108,67 @@ impl Dataset {
     }
 
     pub fn write_mat(&self, dst_pos: Vec3, mat: &Mat) -> Result<usize> {
-            // validate input matrix
-            if mat.voxel_type != self.header.voxel_type {
-                return Err("Input matrix has invalid voxel type");
-            }
+        // validate input matrix
+        if mat.voxel_type != self.header.voxel_type {
+            return Err("Input matrix has invalid voxel type");
+        }
 
-            if mat.voxel_size != self.header.voxel_size as usize {
-                return Err("Input matrix has invalid voxel size");
-            }
+        if mat.voxel_size != self.header.voxel_size as usize {
+            return Err("Input matrix has invalid voxel size");
+        }
 
-            let file_len_vx_log2 = self.header.file_len_vx_log2() as u32;
-            if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {
-                let file_len_vec = Vec3::from(1 << file_len_vx_log2);
-                let is_dst_aligned = dst_pos % file_len_vec == Vec3::from(0);
-                let is_shape_aligned = mat.shape % file_len_vec == Vec3::from(0);
-                if !is_dst_aligned || !is_shape_aligned {
-                    return Err("When writing compressed files, each file has to be \
-                        written as a whole. Please pad your data so that all cubes \
-                        are complete and the write position is block-aligned.");
+        let file_len_vx_log2 = self.header.file_len_vx_log2() as u32;
+        if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {
+            let file_len_vec = Vec3::from(1 << file_len_vx_log2);
+            let is_dst_aligned = dst_pos % file_len_vec == Vec3::from(0);
+            let is_shape_aligned = mat.shape % file_len_vec == Vec3::from(0);
+            if !is_dst_aligned || !is_shape_aligned {
+                return Err("When writing compressed files, each file has to be \
+                            written as a whole. Please pad your data so that all cubes \
+                            are complete and the write position is block-aligned.");
+            }
+        };
+
+        let bbox = Box3::from(mat.shape) + dst_pos;
+
+        // find files to load
+        let bbox_files = Box3::new(
+            bbox.min() >> file_len_vx_log2,
+            ((bbox.max() - 1) >> file_len_vx_log2) + 1,
+        )?;
+
+        for cur_z in bbox_files.min().z..bbox_files.max().z {
+            for cur_y in bbox_files.min().y..bbox_files.max().y {
+                for cur_x in bbox_files.min().x..bbox_files.max().x {
+                    // file path to wkw file
+                    let mut cur_path = self.root.clone();
+                    cur_path.push(format!("z{}", cur_z));
+                    cur_path.push(format!("y{}", cur_y));
+                    cur_path.push(format!("x{}.wkw", cur_x));
+
+                    // bounding box
+                    let cur_file_ids = Vec3 {
+                        x: cur_x,
+                        y: cur_y,
+                        z: cur_z,
+                    };
+                    let cur_file_box = Box3::new(
+                        cur_file_ids << file_len_vx_log2,
+                        (cur_file_ids + 1) << file_len_vx_log2,
+                    )?;
+                    let cur_box = cur_file_box.intersect(bbox);
+
+                    // offsets
+                    let cur_src_pos = cur_box.min() - dst_pos;
+                    let cur_dst_pos = cur_box.min() - cur_file_box.min();
+
+                    let mut file = File::open_or_create(&cur_path, &self.header)?;
+                    file.write_mat(cur_dst_pos, mat, cur_src_pos)?;
                 }
-            };
-
-            let bbox = Box3::from(mat.shape) + dst_pos;
-
-            // find files to load
-            let bbox_files = Box3::new(
-                bbox.min() >> file_len_vx_log2,
-              ((bbox.max() - 1) >> file_len_vx_log2) + 1
-            )?;
-
-            for cur_z in bbox_files.min().z..bbox_files.max().z {
-                for cur_y in bbox_files.min().y..bbox_files.max().y {
-                    for cur_x in bbox_files.min().x..bbox_files.max().x {
-                        // file path to wkw file
-                        let mut cur_path = self.root.clone();
-                        cur_path.push(format!("z{}", cur_z));
-                        cur_path.push(format!("y{}", cur_y));
-                        cur_path.push(format!("x{}.wkw", cur_x));
-
-                        // bounding box
-                        let cur_file_ids = Vec3 { x: cur_x, y: cur_y, z: cur_z };
-                        let cur_file_box = Box3::new(
-                            cur_file_ids << file_len_vx_log2,
-                           (cur_file_ids + 1) << file_len_vx_log2)?;
-                        let cur_box = cur_file_box.intersect(bbox);
-
-                        // offsets
-                        let cur_src_pos = cur_box.min() - dst_pos;
-                        let cur_dst_pos = cur_box.min() - cur_file_box.min();
-
-                        let mut file = File::open_or_create(&cur_path, &self.header)?;
-                        file.write_mat(cur_dst_pos, mat, cur_src_pos)?;
-                    }
-                }
             }
+        }
 
-            Ok(1 as usize)
+        Ok(1 as usize)
     }
 
     pub(crate) fn read_header(root: &Path) -> Result<Header> {
@@ -168,7 +178,7 @@ impl Dataset {
         let mut header_file_opt = fs::File::open(header_path);
         let header_file = match header_file_opt.as_mut() {
             Ok(header_file) => header_file,
-            Err(_) => return Err("Could not open header file")
+            Err(_) => return Err("Could not open header file"),
         };
 
         Header::read(header_file)

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -118,7 +118,7 @@ impl Dataset {
         }
 
         let num_channels = self.header.voxel_type.size() / self.header.voxel_size as usize;
-        if num_channels > 1 && mat.get_is_fortran_order() {
+        if num_channels > 1 && mat.data_in_c_order {
             return Err("Cannot write multichannel data if data is in row-major order.");
         }
 

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -1,14 +1,14 @@
 use lz4;
-use std::{fs, path};
 use std::io::{Read, Seek, SeekFrom, Write};
-use ::{Header, BlockType, Iter, Mat, Morton, Result, Vec3, Box3};
+use std::{fs, path};
+use {BlockType, Box3, Header, Iter, Mat, Morton, Result, Vec3};
 
 #[derive(Debug)]
 pub struct File {
     file: fs::File,
     header: Header,
     block_idx: Option<u64>,
-    block_buf: Option<Box<[u8]>>
+    block_buf: Option<Box<[u8]>>,
 }
 
 impl File {
@@ -18,21 +18,20 @@ impl File {
                 let buf_size = header.max_block_size_on_disk();
                 let buf_vec = vec![0u8; buf_size];
                 Some(buf_vec.into_boxed_slice())
-            },
-            _ => None
+            }
+            _ => None,
         };
 
         File {
             file: file,
             header: header,
             block_idx: None,
-            block_buf: block_buf
+            block_buf: block_buf,
         }
     }
 
     pub fn open(path: &path::Path) -> Result<File> {
-        let mut file = fs::File::open(path)
-                                .or(Err("Could not open WKW file"))?;
+        let mut file = fs::File::open(path).or(Err("Could not open WKW file"))?;
         let header = Header::read(&mut file)?;
         Ok(Self::new(file, header))
     }
@@ -40,20 +39,18 @@ impl File {
     pub(crate) fn open_or_create(path: &path::Path, header: &Header) -> Result<File> {
         // create parent directory, if needed
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-               .or(Err("Could not create parent directory"))?;
+            fs::create_dir_all(parent).or(Err("Could not create parent directory"))?;
         }
 
         let mut open_opts = fs::OpenOptions::new();
         open_opts.read(true).write(true).create(true);
 
-        let mut file = open_opts.open(path)
-                                .or(Err("Could not open file"))?;
+        let mut file = open_opts.open(path).or(Err("Could not open file"))?;
 
         // check if file was created
         let (header, created) = match Header::read(&mut file) {
             Ok(header) => (header, false),
-            Err(_) => (Header::from_template(header), true)
+            Err(_) => (Header::from_template(header), true),
         };
 
         // create structure
@@ -71,7 +68,7 @@ impl File {
         &mut self,
         src_pos: Vec3,
         dst_mat: &mut Mat,
-        dst_pos: Vec3
+        dst_pos: Vec3,
     ) -> Result<usize> {
         let file_len_vx = self.header.file_len_vx();
         let file_len_log2 = self.header.file_len_log2 as u32;
@@ -87,7 +84,7 @@ impl File {
         let src_box = Box3::new(src_pos, src_end)?;
         let src_box_boxes = Box3::new(
             src_box.min() >> block_len_log2,
-          ((src_box.max() - 1) >> block_len_log2) + 1
+            ((src_box.max() - 1) >> block_len_log2) + 1,
         )?;
 
         // allocate buffer
@@ -106,7 +103,8 @@ impl File {
 
             let cur_block_box = Box3::new(
                 cur_block_ids << block_len_log2,
-               (cur_block_ids + 1) << block_len_log2)?;
+                (cur_block_ids + 1) << block_len_log2,
+            )?;
             let cur_box = cur_block_box.intersect(src_box);
 
             // source and destination offsets
@@ -118,7 +116,7 @@ impl File {
             self.read_block(buf)?;
 
             // copy data
-            let src_mat = Mat::new(buf, buf_shape, voxel_size, voxel_type)?;
+            let src_mat = Mat::new(buf, buf_shape, voxel_size, voxel_type, true)?;
             dst_mat.copy_from(cur_dst_pos, &src_mat, cur_src_box)?;
         }
 
@@ -129,18 +127,18 @@ impl File {
         &mut self,
         dst_pos: Vec3,
         src_mat: &Mat,
-        src_pos: Vec3
+        src_pos: Vec3,
     ) -> Result<usize> {
         let block_len_log2 = self.header.block_len_log2 as u32;
 
-        let dst_end = Vec3::from(self.header.file_len_vx())
-                           .elem_min(src_mat.shape - src_pos + dst_pos);
+        let dst_end =
+            Vec3::from(self.header.file_len_vx()).elem_min(src_mat.shape - src_pos + dst_pos);
         let dst_box = Box3::new(dst_pos, dst_end)?;
 
         // bounding boxes
         let dst_box_boxes = Box3::new(
             dst_box.min() >> block_len_log2,
-          ((dst_box.max() - 1) >> block_len_log2) + 1
+            ((dst_box.max() - 1) >> block_len_log2) + 1,
         )?;
 
         // build buffer matrix
@@ -149,7 +147,20 @@ impl File {
             buf.as_mut_slice(),
             Vec3::from(1u32 << block_len_log2),
             self.header.voxel_size as usize,
-            self.header.voxel_type)?;
+            self.header.voxel_type,
+            src_mat.get_is_fortran_order(),
+        )?;
+
+
+        // build second buffer
+        let mut second_buf = vec![0u8; self.header.block_size()];
+        let mut second_buf_mat = Mat::new(
+            second_buf.as_mut_slice(),
+            Vec3::from(1u32 << block_len_log2),
+            self.header.voxel_size as usize,
+            self.header.voxel_type,
+            true,
+        )?;
 
         // build Morton-order iterator
         let iter = Iter::new(self.header.file_len_log2 as u32, dst_box_boxes)?;
@@ -160,7 +171,8 @@ impl File {
 
             let cur_block_box = Box3::new(
                 cur_block_ids << block_len_log2,
-               (cur_block_ids + 1) << block_len_log2)?;
+                (cur_block_ids + 1) << block_len_log2,
+            )?;
             let cur_box = cur_block_box.intersect(dst_box);
 
             if cur_box != cur_block_box {
@@ -177,8 +189,18 @@ impl File {
 
             self.seek_block(cur_block_idx)?;
 
-            // write data
-            self.write_block(buf_mat.as_slice())?;
+            if buf_mat.get_is_fortran_order() {
+                // write data
+                println!("no transpose!");
+                self.write_block(buf_mat.as_slice())?;
+            } else {
+                println!("transpose!");
+                // if buffer is not fortran order
+                // transpose data
+                buf_mat.write_fortran_order_to_buffer(&mut second_buf_mat)?;
+                // write transposed data
+                self.write_block(second_buf_mat.as_slice())?;
+            }
         }
 
         if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {
@@ -197,7 +219,7 @@ impl File {
         // make sure that output path does not exist yet
         let mut file = match path.exists() {
             true => return Err("Output file already exists"),
-            false => Self::open_or_create(path, &header)?
+            false => Self::open_or_create(path, &header)?,
         };
 
         // prepare buffers and jump table
@@ -224,7 +246,7 @@ impl File {
                 let body_size = self.header.file_size();
                 let size = header_size + body_size;
                 size as u64
-            },
+            }
             BlockType::LZ4 | BlockType::LZ4HC => {
                 let last_block_idx = self.header.file_vol() - 1;
                 let jump_table = self.header.jump_table.as_ref().unwrap();
@@ -233,7 +255,9 @@ impl File {
             }
         };
 
-        self.file.set_len(truncated_size).map_err(|_| "Could not truncate file")
+        self.file
+            .set_len(truncated_size)
+            .map_err(|_| "Could not truncate file")
     }
 
     fn seek_header(&mut self) -> Result<()> {
@@ -255,17 +279,17 @@ impl File {
 
         let block_idx = match self.block_idx {
             Some(block_idx) => block_idx,
-            None => return Err("File is not block aligned")
+            None => return Err("File is not block aligned"),
         };
 
         let result = match self.header.block_type {
             BlockType::Raw => self.read_block_raw(buf),
-            BlockType::LZ4 | BlockType::LZ4HC => self.read_block_lz4(buf)
+            BlockType::LZ4 | BlockType::LZ4HC => self.read_block_lz4(buf),
         };
 
         match result {
             Ok(_) => self.block_idx = Some(block_idx + 1),
-            Err(_) => self.block_idx = None
+            Err(_) => self.block_idx = None,
         };
 
         result
@@ -274,18 +298,18 @@ impl File {
     fn write_block(&mut self, buf: &[u8]) -> Result<usize> {
         let block_idx = match self.block_idx {
             Some(block_idx) => block_idx,
-            None => return Err("File is not block aligned")
+            None => return Err("File is not block aligned"),
         };
 
         let result = match self.header.block_type {
             BlockType::Raw => self.write_block_raw(buf),
-            BlockType::LZ4 | BlockType::LZ4HC => self.write_block_lz4(buf)
+            BlockType::LZ4 | BlockType::LZ4HC => self.write_block_lz4(buf),
         };
 
         // advance
         match result {
             Ok(_) => self.block_idx = Some(block_idx + 1),
-            Err(_) => self.block_idx = None
+            Err(_) => self.block_idx = None,
         };
 
         result
@@ -294,14 +318,14 @@ impl File {
     fn read_block_raw(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self.file.read_exact(buf) {
             Ok(_) => Ok(buf.len()),
-            Err(_) => Err("Could not read raw block")
+            Err(_) => Err("Could not read raw block"),
         }
     }
 
     fn write_block_raw(&mut self, buf: &[u8]) -> Result<usize> {
         match self.file.write_all(buf) {
             Ok(_) => Ok(buf.len()),
-            Err(_) => Err("Could not write raw block")
+            Err(_) => Err("Could not write raw block"),
         }
     }
 
@@ -311,12 +335,15 @@ impl File {
         let len_lz4 = lz4::compress_hc(buf, &mut buf_lz4)?;
 
         // write data
-        self.file.write_all(&buf_lz4[..len_lz4])
-                 .or(Err("Could not write LZ4 block"))?;
+        self.file
+            .write_all(&buf_lz4[..len_lz4])
+            .or(Err("Could not write LZ4 block"))?;
 
         // update jump table
-        let jump_entry = self.file.seek(SeekFrom::Current(0))
-                                  .or(Err("Could not determine jump entry"))?;
+        let jump_entry = self
+            .file
+            .seek(SeekFrom::Current(0))
+            .or(Err("Could not determine jump entry"))?;
 
         let block_idx = self.block_idx.unwrap();
         let jump_table = &mut *self.header.jump_table.as_mut().unwrap();
@@ -334,21 +361,22 @@ impl File {
         let buf_lz4 = &mut buf_lz4_orig[..block_size_lz4];
 
         // read compressed block
-        self.file.read_exact(buf_lz4)
-                 .or(Err("Error while reading LZ4 block"))?;
+        self.file
+            .read_exact(buf_lz4)
+            .or(Err("Error while reading LZ4 block"))?;
 
         // decompress block
         let byte_written = lz4::decompress_safe(buf_lz4, buf)?;
 
         match byte_written == block_size_raw {
             true => Ok(byte_written),
-            false => Err("Unexpected length after decompression")
+            false => Err("Unexpected length after decompression"),
         }
     }
 
     fn seek_block(&mut self, block_idx: u64) -> Result<u64> {
         if self.block_idx == Some(block_idx) {
-            return Ok(block_idx)
+            return Ok(block_idx);
         }
 
         // determine block offset

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -151,7 +151,6 @@ impl File {
             src_mat.get_is_fortran_order(),
         )?;
 
-
         // build second buffer
         let mut second_buf = vec![0u8; self.header.block_size()];
         let mut second_buf_mat = Mat::new(
@@ -191,10 +190,8 @@ impl File {
 
             if buf_mat.get_is_fortran_order() {
                 // write data
-                println!("no transpose!");
                 self.write_block(buf_mat.as_slice())?;
             } else {
-                println!("transpose!");
                 // if buffer is not fortran order
                 // transpose data
                 buf_mat.write_fortran_order_to_buffer(&mut second_buf_mat)?;

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -116,7 +116,7 @@ impl File {
             self.read_block(buf)?;
 
             // copy data
-            let src_mat = Mat::new(buf, buf_shape, voxel_size, voxel_type, true)?;
+            let src_mat = Mat::new(buf, buf_shape, voxel_size, voxel_type, false)?;
             dst_mat.copy_from(cur_dst_pos, &src_mat, cur_src_box)?;
         }
 
@@ -148,7 +148,7 @@ impl File {
             Vec3::from(1u32 << block_len_log2),
             self.header.voxel_size as usize,
             self.header.voxel_type,
-            src_mat.get_is_fortran_order(),
+            src_mat.data_in_c_order,
         )?;
 
         // build second buffer
@@ -158,7 +158,7 @@ impl File {
             Vec3::from(1u32 << block_len_log2),
             self.header.voxel_size as usize,
             self.header.voxel_type,
-            true,
+            false,
         )?;
 
         // build Morton-order iterator
@@ -189,11 +189,11 @@ impl File {
             self.seek_block(cur_block_idx)?;
 
             // write in fortran order
-            if buf_mat.get_is_fortran_order() {
-                self.write_block(buf_mat.as_slice())?;
-            } else {
+            if buf_mat.data_in_c_order {
                 buf_mat.copy_as_fortran_order(&mut fortran_conversion_mat)?;
                 self.write_block(fortran_conversion_mat.as_slice())?;
+            } else {
+                self.write_block(buf_mat.as_slice())?;
             }
         }
 

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -189,12 +189,13 @@ impl File {
             self.seek_block(cur_block_idx)?;
 
             // write in fortran order
-            if buf_mat.data_in_c_order {
+            let buffer_to_write = if buf_mat.data_in_c_order {
                 buf_mat.copy_as_fortran_order(&mut fortran_conversion_mat)?;
-                self.write_block(fortran_conversion_mat.as_slice())?;
+                &fortran_conversion_mat
             } else {
-                self.write_block(buf_mat.as_slice())?;
-            }
+                &buf_mat
+            };
+            self.write_block(buffer_to_write.as_slice())?;
         }
 
         if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -192,7 +192,7 @@ impl File {
             if buf_mat.get_is_fortran_order() {
                 self.write_block(buf_mat.as_slice())?;
             } else {
-                buf_mat.write_fortran_order_to_buffer(&mut fortran_conversion_mat)?;
+                buf_mat.copy_as_fortran_order(&mut fortran_conversion_mat)?;
                 self.write_block(fortran_conversion_mat.as_slice())?;
             }
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,8 +13,8 @@ mod lz4;
 // convenience
 pub use dataset::Dataset;
 pub use file::File;
-pub use header::{Header, BlockType, VoxelType};
+pub use header::{BlockType, Header, VoxelType};
 pub use mat::Mat;
-pub use morton::{Morton, Iter};
+pub use morton::{Iter, Morton};
 pub use result::Result;
 pub use vec::{Box3, Vec3};

--- a/rust/src/lz4.rs
+++ b/rust/src/lz4.rs
@@ -1,11 +1,11 @@
 extern crate libc;
 use self::libc::c_int;
-use ::Result;
+use Result;
 
 #[cfg_attr(target_os = "linux", link(name = "lz4", kind = "dylib"))]
 #[cfg_attr(target_os = "macos", link(name = "lz4", kind = "dylib"))]
 #[cfg_attr(target_os = "windows", link(name = "liblz4", kind = "dylib"))]
-extern {
+extern "C" {
     // upper bound
     fn LZ4_compressBound(input_size: c_int) -> c_int;
 
@@ -15,7 +15,7 @@ extern {
         dst: *mut u8,
         src_size: c_int,
         dst_capacity: c_int,
-        compression_level: c_int
+        compression_level: c_int,
     ) -> c_int;
 
     // decompression
@@ -23,7 +23,7 @@ extern {
         src_buf: *const u8,
         dst_buf: *mut u8,
         compressed_size: c_int,
-        max_decompressed_size: c_int
+        max_decompressed_size: c_int,
     ) -> c_int;
 }
 
@@ -42,13 +42,13 @@ pub fn compress_hc(src_buf: &[u8], dst_buf: &mut [u8]) -> Result<usize> {
             dst_buf.as_mut_ptr(),
             src_size,
             dst_capacity,
-            compression_level
+            compression_level,
         )
     };
 
     match dst_len == 0 {
         true => Err("Error in LZ4_compress_HC"),
-        false => Ok(dst_len as usize)
+        false => Ok(dst_len as usize),
     }
 }
 
@@ -61,12 +61,12 @@ pub fn decompress_safe(src_buf: &[u8], dst_buf: &mut [u8]) -> Result<usize> {
             src_buf.as_ptr(),
             dst_buf.as_mut_ptr(),
             compressed_size,
-            max_decompressed_size
+            max_decompressed_size,
         )
     };
 
     match dst_len < 0 {
         true => Err("Error in LZ4_decompress_safe"),
-        false => Ok(dst_len as usize)
+        false => Ok(dst_len as usize),
     }
 }

--- a/rust/src/mat.rs
+++ b/rust/src/mat.rs
@@ -54,8 +54,7 @@ impl<'a> Mat<'a> {
 
     fn offset(&self, pos: Vec3) -> usize {
         let offset_vx = if self.is_fortran_order {
-             pos.x + self.shape.x * (pos.y + self.shape.y * pos.z)
-
+            pos.x + self.shape.x * (pos.y + self.shape.y * pos.z)
         } else {
             pos.z + self.shape.z * (pos.y + self.shape.y * pos.x)
         };
@@ -81,7 +80,6 @@ impl<'a> Mat<'a> {
         let x_length = self.shape.x as usize;
         let y_length = self.shape.y as usize;
         let z_length = self.shape.z as usize;
-
 
         let row_major_stride: Vec<usize> = vec![
             z_length * y_length * self.voxel_size,
@@ -137,29 +135,32 @@ impl<'a> Mat<'a> {
 
         let width = src_box.width();
         // unified has fast to slow moving indices
-        let unified_width = match self.is_fortran_order {
-            true => width,
-            false => Vec3 {
+        let unified_width = if self.is_fortran_order {
+            width
+        } else {
+            Vec3 {
                 x: width.z,
                 y: width.y,
                 z: width.x,
-            },
+            }
         };
-        let unified_dst_shape = match self.is_fortran_order {
-            true => self.shape,
-            false => Vec3 {
+        let unified_dst_shape = if self.is_fortran_order {
+            self.shape
+        } else {
+            Vec3 {
                 x: self.shape.z,
                 y: self.shape.y,
                 z: self.shape.x,
-            },
+            }
         };
-        let unified_src_shape = match self.is_fortran_order {
-            true => src.shape,
-            false => Vec3 {
+        let unified_src_shape = if self.is_fortran_order {
+            src.shape
+        } else {
+            Vec3 {
                 x: src.shape.z,
                 y: src.shape.y,
                 z: src.shape.x,
-            },
+            }
         };
 
         let stripe_len = src.voxel_size * unified_width.x as usize;

--- a/rust/src/mat.rs
+++ b/rust/src/mat.rs
@@ -1,13 +1,14 @@
 use std::ptr;
 
-use ::{Box3, Result, Vec3, VoxelType};
+use {Box3, Result, Vec3, VoxelType};
 
 #[derive(Debug)]
 pub struct Mat<'a> {
     data: &'a mut [u8],
     pub shape: Vec3,
     pub voxel_size: usize,
-    pub voxel_type: VoxelType
+    pub voxel_type: VoxelType,
+    is_fortran_order: bool,
 }
 
 impl<'a> Mat<'a> {
@@ -15,78 +16,198 @@ impl<'a> Mat<'a> {
         data: &mut [u8],
         shape: Vec3,
         voxel_size: usize,
-        voxel_type: VoxelType
+        voxel_type: VoxelType,
+        is_fortran_array: bool,
     ) -> Result<Mat> {
         // make sure that slice is large enough
         let numel = shape.x as usize * shape.y as usize * shape.z as usize;
         let expected_len = numel * voxel_size;
-
         if data.len() != expected_len {
-            return Err("Length of slice does not match expected size")
+            return Err("Length of slice does not match expected size");
         }
 
         if voxel_size % voxel_type.size() != 0 {
-            return Err("Voxel size must be a multiple of voxel type size")
+            return Err("Voxel size must be a multiple of voxel type size");
         }
 
         Ok(Mat {
             data: data,
             shape: shape,
             voxel_size: voxel_size,
-            voxel_type: voxel_type
+            voxel_type: voxel_type,
+            is_fortran_order: is_fortran_array,
         })
     }
 
-    pub fn as_slice(&self) -> &[u8] { self.data }
-    pub fn as_mut_slice(&mut self) -> &mut [u8] { self.data }
-    pub fn as_mut_ptr(&mut self) -> *mut u8 { self.data.as_mut_ptr() }
+    pub fn get_is_fortran_order(&self) -> bool {
+        return self.is_fortran_order;
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        self.data
+    }
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.data
+    }
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.data.as_mut_ptr()
+    }
 
     fn offset(&self, pos: Vec3) -> usize {
-        let offset_vx =
-            pos.x as usize + self.shape.x as usize * (
-            pos.y as usize + self.shape.y as usize * pos.z as usize);
+        if self.is_fortran_order {
+            let offset_vx = pos.x as usize
+                + self.shape.x as usize * (pos.y as usize + self.shape.y as usize * pos.z as usize);
+            offset_vx * self.voxel_size
+        }
+        else {
+            let offset_vx = pos.z as usize
+                + self.shape.z as usize * (pos.y as usize + self.shape.y as usize * pos.x as usize);
+            offset_vx * self.voxel_size
+        }
 
-        offset_vx * self.voxel_size
+
+
+    }
+
+    pub fn write_fortran_order_to_buffer(&self, buffer: &mut Mat) -> Result<()> {
+        if self.is_fortran_order {
+            return Err("Mat is already in fortran order");
+        }
+        if self.voxel_size != buffer.voxel_size {
+            return Err("Matrices mismatch in voxel size");
+        }
+        if self.voxel_type != buffer.voxel_type {
+            return Err("Matrices mismatch in voxel type");
+        }
+        if self.shape != buffer.shape {
+            return Err("Matrices mismatch in shape");
+        }
+        println!("shape: {:?}", self.shape);
+        let buffer_data = buffer.as_mut_slice();
+        // x y z
+        let x_length = self.shape.x as usize;
+        let y_length = self.shape.y as usize;
+        let z_length = self.shape.z as usize;
+
+        let row_major_stride: Vec<usize> = vec![ z_length * y_length * self.voxel_size, z_length * self.voxel_size, self.voxel_size];
+        let column_major_stride: Vec<usize> = vec![ self.voxel_size,  x_length * self.voxel_size, x_length * y_length * self.voxel_size];
+        // Do continuous read in z. Last dim in Row-Major is continuous.
+        //buffer_data[0] = self.data[0]; // x: 0 y: 0 z: 0
+        //buffer_data[32] = self.data[1]; // x: 0 y: 0 z:1
+        //buffer_data[1] = self.data[32]; // x: 0 y: 1 z: 0
+        //buffer_data[33] = self.data[33]; // x:0 y: 1 z: 1
+        //println!("read value {}", self.data[0]);
+        //println!("read value {}", self.data[1]);
+        //println!("read value {}", self.data[32]);
+        //println!("read value {}", self.data[33]);
+        for x in 0usize..x_length {
+            for y in 0usize..y_length {
+                for z in 0usize..z_length {
+                    let row_major_index =
+                        x * row_major_stride[0] + y * row_major_stride[1] + z * row_major_stride[2];
+                    let column_major_index = x * column_major_stride[0]
+                        + y * column_major_stride[1]
+                        + z * column_major_stride[2];
+                    for byte_offset in 0..self.voxel_size {
+                        buffer_data[column_major_index as usize + byte_offset as usize] =
+                            self.data[row_major_index as usize + byte_offset as usize];
+                    }
+                    //if row_major_index < 2 {
+                    //    println!("read value {}", self.data[row_major_index]);
+                    //}
+                    //if row_major_index >= row_major_stride[1]  && row_major_index < row_major_stride[1] +2 {
+                    //    println!("read value {}", self.data[row_major_index]);
+                    //}
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn copy_from(&mut self, dst_pos: Vec3, src: &Mat, src_box: Box3) -> Result<()> {
         // make sure that matrices are matching
-        if self.voxel_size != src.voxel_size { return Err("Matrices mismatch in voxel size"); }
-        if self.voxel_type != src.voxel_type { return Err("Matrices mismatch in voxel type"); }
+        if self.voxel_size != src.voxel_size {
+            return Err("Matrices mismatch in voxel size");
+        }
+        if self.voxel_type != src.voxel_type {
+            return Err("Matrices mismatch in voxel type");
+        }
 
-        if !(src_box.max() < (src.shape + 1)) { return Err("Reading out of bounds"); }
-        if !(dst_pos + src_box.width() < (self.shape + 1)) { return Err("Writing out of bounds"); }
+        if !(src_box.max() < (src.shape + 1)) {
+            return Err("Reading out of bounds");
+        }
+        if !(dst_pos + src_box.width() < (self.shape + 1)) {
+            return Err("Writing out of bounds");
+        }
+        if self.is_fortran_order != src.get_is_fortran_order() {
+            return Err("source and destination has to be same order");
+        }
 
         let len = src_box.width();
-        let stripe_len = src.voxel_size * len.x as usize;
 
-        let src_off_y = (src.shape.x as usize * src.voxel_size) as isize;
-        let src_off_z = (src.shape.x as usize * src.shape.y as usize * self.voxel_size) as isize;
+        if self.is_fortran_order {
 
-        let dst_off_y = (self.shape.x as usize * self.voxel_size) as isize;
-        let dst_off_z = (self.shape.x as usize * self.shape.y as usize * self.voxel_size) as isize;
+            let stripe_len = src.voxel_size * len.x as usize;
 
-        unsafe {
-            let mut src_ptr = src.data.as_ptr().offset(src.offset(src_box.min()) as isize);
-            let mut dst_ptr = self.data.as_mut_ptr().offset(self.offset(dst_pos) as isize);
+            let src_off_y = (src.shape.x as usize * src.voxel_size) as isize;
+            let src_off_z = (src.shape.x as usize * src.shape.y as usize * self.voxel_size) as isize;
 
-            for _ in 0..len.z {
-                let mut src_ptr_cur = src_ptr;
-                let mut dst_ptr_cur = dst_ptr;
+            let dst_off_y = (self.shape.x as usize * self.voxel_size) as isize;
+            let dst_off_z = (self.shape.x as usize * self.shape.y as usize * self.voxel_size) as isize;
 
-                for _ in 0..len.y {
-                    // copy data
-                    ptr::copy_nonoverlapping(src_ptr_cur, dst_ptr_cur, stripe_len);
+            unsafe {
+                let mut src_ptr = src.data.as_ptr().offset(src.offset(src_box.min()) as isize);
+                let mut dst_ptr = self.data.as_mut_ptr().offset(self.offset(dst_pos) as isize);
 
-                    // advance
-                    src_ptr_cur = src_ptr_cur.offset(src_off_y);
-                    dst_ptr_cur = dst_ptr_cur.offset(dst_off_y);
+                for _ in 0..len.z {
+                    let mut src_ptr_cur = src_ptr;
+                    let mut dst_ptr_cur = dst_ptr;
+
+                    for _ in 0..len.y {
+                        // copy data
+                        ptr::copy_nonoverlapping(src_ptr_cur, dst_ptr_cur, stripe_len);
+
+                        // advance
+                        src_ptr_cur = src_ptr_cur.offset(src_off_y);
+                        dst_ptr_cur = dst_ptr_cur.offset(dst_off_y);
+                    }
+
+                    src_ptr = src_ptr.offset(src_off_z);
+                    dst_ptr = dst_ptr.offset(dst_off_z);
                 }
-
-                src_ptr = src_ptr.offset(src_off_z);
-                dst_ptr = dst_ptr.offset(dst_off_z);
             }
         }
+        else {
+            // copy row-major order
+            println!("copy row-major order");
+            unsafe {
+                let mut src_ptr = src.data.as_ptr().offset(src.offset(src_box.min()) as isize);
+                let mut dst_ptr = self.data.as_mut_ptr().offset(self.offset(dst_pos) as isize);
+
+                let stripe_len = src.voxel_size * len.z as usize;
+                let src_off_y = (src.shape.z as usize * src.voxel_size) as isize;
+                let src_off_x = (src.shape.z as usize * src.shape.y as usize * self.voxel_size) as isize;
+
+                let dst_off_y = (self.shape.z as usize * self.voxel_size) as isize;
+                let dst_off_x = (self.shape.z as usize * self.shape.y as usize * self.voxel_size) as isize;
+
+                for _ in 0..len.x {
+                    let mut src_ptr_cur = src_ptr;
+                    let mut dst_ptr_cur = dst_ptr;
+
+                    for _ in 0..len.y {
+                        // copy data
+                        ptr::copy_nonoverlapping(src_ptr_cur, dst_ptr_cur, stripe_len);
+                        // advance
+                        src_ptr_cur = src_ptr_cur.offset(src_off_y);
+                        dst_ptr_cur = dst_ptr_cur.offset(dst_off_y);
+                    }
+                    src_ptr = src_ptr.offset(src_off_x);
+                    dst_ptr = dst_ptr.offset(dst_off_x);
+                }
+            }
+
+        }
+
 
         Ok(())
     }

--- a/rust/src/morton.rs
+++ b/rust/src/morton.rs
@@ -1,26 +1,26 @@
 use std::cmp;
-use ::{Box3, Result, Vec3};
+use {Box3, Result, Vec3};
 
 #[derive(PartialEq, Debug)]
 pub struct Morton(u64);
 
 fn shuffle(v: u64) -> u64 {
     // take first 21 bits
-    let mut z =       v & 0x00000000001fffff;
+    let mut z = v & 0x00000000001fffff;
     z = (z | (z << 32)) & 0x001f00000000ffff;
     z = (z | (z << 16)) & 0x001f0000ff0000ff;
-    z = (z | (z <<  8)) & 0x100f00f00f00f00f;
-    z = (z | (z <<  4)) & 0x100f00f00f00f00f;
-    z = (z | (z <<  2)) & 0x1249249249249249;
+    z = (z | (z << 8)) & 0x100f00f00f00f00f;
+    z = (z | (z << 4)) & 0x100f00f00f00f00f;
+    z = (z | (z << 2)) & 0x1249249249249249;
 
     z
 }
 
 fn unshuffle(z: u64) -> u64 {
-    let mut v =       z & 0x1249249249249249;
-    v = (v ^ (v >>  2)) & 0x10c30c30c30c30c3;
-    v = (v ^ (v >>  4)) & 0x100f00f00f00f00f;
-    v = (v ^ (v >>  8)) & 0x001f0000ff0000ff;
+    let mut v = z & 0x1249249249249249;
+    v = (v ^ (v >> 2)) & 0x10c30c30c30c30c3;
+    v = (v ^ (v >> 4)) & 0x100f00f00f00f00f;
+    v = (v ^ (v >> 8)) & 0x001f0000ff0000ff;
     v = (v ^ (v >> 16)) & 0x001f00000000ffff;
     v = (v ^ (v >> 32)) & 0x00000000001fffff;
 
@@ -30,9 +30,9 @@ fn unshuffle(z: u64) -> u64 {
 impl<'a> From<&'a Vec3> for Morton {
     fn from(vec: &'a Vec3) -> Morton {
         Morton(
-            (shuffle(vec.x as u64) << 0) |
-            (shuffle(vec.y as u64) << 1) |
-            (shuffle(vec.z as u64) << 2)
+            (shuffle(vec.x as u64) << 0)
+                | (shuffle(vec.y as u64) << 1)
+                | (shuffle(vec.z as u64) << 2),
         )
     }
 }
@@ -42,17 +42,21 @@ impl From<Morton> for Vec3 {
         Vec3 {
             x: unshuffle(idx.0 >> 0) as u32,
             y: unshuffle(idx.0 >> 1) as u32,
-            z: unshuffle(idx.0 >> 2) as u32
+            z: unshuffle(idx.0 >> 2) as u32,
         }
     }
 }
 
 impl From<Morton> for u64 {
-    fn from(idx: Morton) -> u64 { idx.0 }
+    fn from(idx: Morton) -> u64 {
+        idx.0
+    }
 }
 
 impl From<u64> for Morton {
-    fn from(idx: u64) -> Morton { Morton(idx) }
+    fn from(idx: u64) -> Morton {
+        Morton(idx)
+    }
 }
 
 pub struct Iter {
@@ -115,8 +119,8 @@ impl Iterator for Iter {
                 Some((start, end)) => {
                     self.idx = start;
                     self.end = end;
-                },
-                None => return None
+                }
+                None => return None,
             }
         }
 
@@ -128,30 +132,30 @@ impl Iterator for Iter {
 
 #[test]
 fn test_encoding() {
-    assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 0 }) == Morton::from(0  as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 0, z: 0 }) == Morton::from(1  as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 1, z: 0 }) == Morton::from(2  as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 1, z: 0 }) == Morton::from(3  as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 1 }) == Morton::from(4  as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 0, z: 1 }) == Morton::from(5  as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 1, z: 1 }) == Morton::from(6  as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 1, z: 1 }) == Morton::from(7  as u64));
-    assert!(Morton::from(&Vec3 { x: 2, y: 0, z: 0 }) == Morton::from(8  as u64));
+    assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 0 }) == Morton::from(0 as u64));
+    assert!(Morton::from(&Vec3 { x: 1, y: 0, z: 0 }) == Morton::from(1 as u64));
+    assert!(Morton::from(&Vec3 { x: 0, y: 1, z: 0 }) == Morton::from(2 as u64));
+    assert!(Morton::from(&Vec3 { x: 1, y: 1, z: 0 }) == Morton::from(3 as u64));
+    assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 1 }) == Morton::from(4 as u64));
+    assert!(Morton::from(&Vec3 { x: 1, y: 0, z: 1 }) == Morton::from(5 as u64));
+    assert!(Morton::from(&Vec3 { x: 0, y: 1, z: 1 }) == Morton::from(6 as u64));
+    assert!(Morton::from(&Vec3 { x: 1, y: 1, z: 1 }) == Morton::from(7 as u64));
+    assert!(Morton::from(&Vec3 { x: 2, y: 0, z: 0 }) == Morton::from(8 as u64));
     assert!(Morton::from(&Vec3 { x: 0, y: 2, z: 0 }) == Morton::from(16 as u64));
     assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 2 }) == Morton::from(32 as u64));
 }
 
 #[test]
 fn test_decoding() {
-    assert!(Vec3 { x: 0, y: 0, z: 0 } == Vec3::from(Morton::from(0  as u64)));
-    assert!(Vec3 { x: 1, y: 0, z: 0 } == Vec3::from(Morton::from(1  as u64)));
-    assert!(Vec3 { x: 0, y: 1, z: 0 } == Vec3::from(Morton::from(2  as u64)));
-    assert!(Vec3 { x: 1, y: 1, z: 0 } == Vec3::from(Morton::from(3  as u64)));
-    assert!(Vec3 { x: 0, y: 0, z: 1 } == Vec3::from(Morton::from(4  as u64)));
-    assert!(Vec3 { x: 1, y: 0, z: 1 } == Vec3::from(Morton::from(5  as u64)));
-    assert!(Vec3 { x: 0, y: 1, z: 1 } == Vec3::from(Morton::from(6  as u64)));
-    assert!(Vec3 { x: 1, y: 1, z: 1 } == Vec3::from(Morton::from(7  as u64)));
-    assert!(Vec3 { x: 2, y: 0, z: 0 } == Vec3::from(Morton::from(8  as u64)));
+    assert!(Vec3 { x: 0, y: 0, z: 0 } == Vec3::from(Morton::from(0 as u64)));
+    assert!(Vec3 { x: 1, y: 0, z: 0 } == Vec3::from(Morton::from(1 as u64)));
+    assert!(Vec3 { x: 0, y: 1, z: 0 } == Vec3::from(Morton::from(2 as u64)));
+    assert!(Vec3 { x: 1, y: 1, z: 0 } == Vec3::from(Morton::from(3 as u64)));
+    assert!(Vec3 { x: 0, y: 0, z: 1 } == Vec3::from(Morton::from(4 as u64)));
+    assert!(Vec3 { x: 1, y: 0, z: 1 } == Vec3::from(Morton::from(5 as u64)));
+    assert!(Vec3 { x: 0, y: 1, z: 1 } == Vec3::from(Morton::from(6 as u64)));
+    assert!(Vec3 { x: 1, y: 1, z: 1 } == Vec3::from(Morton::from(7 as u64)));
+    assert!(Vec3 { x: 2, y: 0, z: 0 } == Vec3::from(Morton::from(8 as u64)));
     assert!(Vec3 { x: 0, y: 2, z: 0 } == Vec3::from(Morton::from(16 as u64)));
     assert!(Vec3 { x: 0, y: 0, z: 2 } == Vec3::from(Morton::from(32 as u64)));
 }

--- a/rust/src/vec.rs
+++ b/rust/src/vec.rs
@@ -77,6 +77,14 @@ impl Vec3 {
             z: min(self.z, other.z),
         }
     }
+
+    pub fn flip(&self) -> Vec3 {
+        Vec3 {
+            x: self.z,
+            y: self.y,
+            z: self.x,
+        }
+    }
 }
 
 // based on bluss' ndarray

--- a/rust/src/vec.rs
+++ b/rust/src/vec.rs
@@ -1,17 +1,17 @@
-use std::cmp::{min, max, Ordering};
-use ::Result;
+use std::cmp::{max, min, Ordering};
+use Result;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec3 {
     pub x: u32,
     pub y: u32,
-    pub z: u32
+    pub z: u32,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Box3 {
     min: Vec3,
-    max: Vec3
+    max: Vec3,
 }
 
 impl Box3 {
@@ -22,20 +22,24 @@ impl Box3 {
         }
     }
 
-    pub fn min(&self) -> Vec3 { self.min }
-    pub fn max(&self) -> Vec3 { self.max }
-    pub fn width(&self) -> Vec3 { self.max - self.min }
+    pub fn min(&self) -> Vec3 {
+        self.min
+    }
+    pub fn max(&self) -> Vec3 {
+        self.max
+    }
+    pub fn width(&self) -> Vec3 {
+        self.max - self.min
+    }
 
     pub fn is_empty(&self) -> bool {
-        (self.min.x == self.max.x)
-      | (self.min.y == self.max.y)
-      | (self.min.z == self.max.z)
+        (self.min.x == self.max.x) | (self.min.y == self.max.y) | (self.min.z == self.max.z)
     }
 
     pub fn intersect(&self, rhs: Box3) -> Box3 {
         Box3 {
             min: self.min.elem_max(rhs.min).elem_min(self.max),
-            max: self.max.elem_min(rhs.max).elem_max(self.min)
+            max: self.max.elem_min(rhs.max).elem_max(self.min),
         }
     }
 }
@@ -44,7 +48,7 @@ impl From<Vec3> for Box3 {
     fn from(max: Vec3) -> Box3 {
         Box3 {
             min: Vec3::from(0u32),
-            max: max
+            max: max,
         }
     }
 }
@@ -62,7 +66,7 @@ impl Vec3 {
         Vec3 {
             x: max(self.x, other.x),
             y: max(self.y, other.y),
-            z: max(self.z, other.z)
+            z: max(self.z, other.z),
         }
     }
 
@@ -70,7 +74,7 @@ impl Vec3 {
         Vec3 {
             x: min(self.x, other.x),
             y: min(self.y, other.y),
-            z: min(self.z, other.z)
+            z: min(self.z, other.z),
         }
     }
 }
@@ -158,9 +162,9 @@ impl PartialOrd for Vec3 {
     fn partial_cmp(&self, rhs: &Vec3) -> Option<Ordering> {
         match (self.x.cmp(&rhs.x), self.y.cmp(&rhs.y), self.z.cmp(&rhs.z)) {
             (Ordering::Greater, Ordering::Greater, Ordering::Greater) => Some(Ordering::Greater),
-            (Ordering::Equal  , Ordering::Equal  , Ordering::Equal)   => Some(Ordering::Equal),
-            (Ordering::Less   , Ordering::Less   , Ordering::Less)    => Some(Ordering::Less),
-            _                                                         => None
+            (Ordering::Equal, Ordering::Equal, Ordering::Equal) => Some(Ordering::Equal),
+            (Ordering::Less, Ordering::Less, Ordering::Less) => Some(Ordering::Less),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
This PR improves the write performance of row-major input data.

Before, the input data was converted by python to column-major and then passed to the rust library.
This conversion was done using `np.asfortranarray`. It turns out that this is unnecessarily slow.

In order to circumvent this issue, the python library determines whether the data is row or column-major and passes this information down to the rust lib.
The data is then converted on the fly using two buffers. 
This way, column-major order is written in any case.

The first buffer contains the data to write in the same order as the input data.
The second buffer is used only if the input data is in row-major and holds the column-major version of the first buffer.

The write performance for 1 Gibibyte on my laptop:
Before:
Write data column-major: 1.14s
Write data row-major: 46.1s

After:
Write data column-major: 1.23s
Write data row-major: 1.11s

Closes #38 