### PR TITLE
Fix writing incomplete block

### DIFF
--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -56,7 +56,7 @@ jobs:
            bash -c "\$PYBIN/python setup.py sdist bdist_wheel -p manylinux1_x86_64 && \$PYBIN/twine upload dist/*.whl dist/*.tar.gz"
 
   build_mac:
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -128,12 +128,12 @@ jobs:
         cd python
         python -c "import wkw"
         pip install pytest
-        pytest tests
+        pytest tests -k "not big_read"
     - name: Test (non-bash)
       run: |
         cd python
         python -c "import wkw"
-        pytest tests
+        pytest tests -k "not big_read"
     - name: Publish
       shell: bash
       if: startsWith(github.event.ref, 'refs/tags')

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -247,6 +247,7 @@ def test_view_on_np_array():
 
     assert np.all(data == read_data)
 
+
 def test_not_too_much_data_is_written_in_column_order():
     data_shape = (35, 35, 35)
     data = generate_test_data(np.uint8, data_shape, order="F")
@@ -258,6 +259,7 @@ def test_not_too_much_data_is_written_in_column_order():
 
     assert np.all(data == read_data[0, :, :, :35])
     assert np.all(read_data[0, :, :, 35:] == 1)
+
 
 def test_not_too_much_data_is_written_in_row_order():
     data_shape = (35, 35, 35)

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -270,7 +270,7 @@ def test_not_too_much_data_is_written():
 
 def test_multiple_writes_and_reads():
 
-    mem_buffer = np.zeros((200, 200, 200))
+    mem_buffer = np.zeros((200, 200, 200), dtype=np.uint8, order="F")
     with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
         for i in range(10):
             offset = np.random.randint(100, size=(3))
@@ -286,6 +286,23 @@ def test_multiple_writes_and_reads():
 
             read_data = dataset.read((0, 0, 0), (200, 200, 200))
             assert np.all(mem_buffer == read_data)
+
+
+def test_big_read():
+    data = np.ones((10, 10, 764), order="C", dtype=np.uint8)
+    offset = np.array([0, 0, 640])
+    bottom = (2000, 2000, 2000)
+    mem_buffer = np.zeros(bottom, dtype=np.uint8, order="F")
+
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
+        dataset.write(offset, data)
+        mem_buffer[
+            offset[0] : offset[0] + data.shape[0],
+            offset[1] : offset[1] + data.shape[1],
+            offset[2] : offset[2] + data.shape[2],
+        ] = data
+        read_data = dataset.read((0, 0, 0), bottom)
+        assert np.all(read_data == mem_buffer)
 
 
 def generate_test_data(dtype, size=SIZE, order="C"):

--- a/python/tests/test_wkw.py
+++ b/python/tests/test_wkw.py
@@ -247,6 +247,30 @@ def test_view_on_np_array():
 
     assert np.all(data == read_data)
 
+def test_not_too_much_data_is_written_in_column_order():
+    data_shape = (35, 35, 35)
+    data = generate_test_data(np.uint8, data_shape, order="F")
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
+        dataset.write((0, 0, 0), np.ones((35, 35, 64), dtype=np.uint8))
+        dataset.write((0, 0, 0), data)
+
+        read_data = dataset.read((0, 0, 0), (35, 35, 64))
+
+    assert np.all(data == read_data[0, :, :, :35])
+    assert np.all(read_data[0, :, :, 35:] == 1)
+
+def test_not_too_much_data_is_written_in_row_order():
+    data_shape = (35, 35, 35)
+    data = generate_test_data(np.uint8, data_shape, order="C")
+    with wkw.Dataset.create("tests/tmp", wkw.Header(np.uint8)) as dataset:
+        dataset.write((0, 0, 0), np.ones((35, 35, 64), dtype=np.uint8))
+        dataset.write((0, 0, 0), data)
+
+        read_data = dataset.read((0, 0, 0), (35, 35, 64))
+
+    assert np.all(data == read_data[0, :, :, :35])
+    assert np.all(read_data[0, :, :, 35:] == 1)
+
 
 def generate_test_data(dtype, size=SIZE, order="C"):
     return np.array(

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -148,7 +148,7 @@ impl File {
             Vec3::from(1u32 << block_len_log2),
             self.header.voxel_size as usize,
             self.header.voxel_type,
-            src_mat.data_in_c_order,
+            false,
         )?;
 
         // build second buffer
@@ -158,7 +158,7 @@ impl File {
             Vec3::from(1u32 << block_len_log2),
             self.header.voxel_size as usize,
             self.header.voxel_type,
-            false,
+            true,
         )?;
 
         // build Morton-order iterator
@@ -177,31 +177,24 @@ impl File {
             if cur_box != cur_block_box {
                 // reuse existing data
                 self.seek_block(cur_block_idx)?;
-                let buffer_to_initialize = if src_block_buf_mat.data_in_c_order {
-                    &mut raw_disk_block_buf_mat
-                } else {
-                    &mut src_block_buf_mat
-                };
-                self.read_block(buffer_to_initialize.as_mut_slice())?;
+                self.read_block(src_block_buf_mat.as_mut_slice())?;
             }
 
             let cur_src_box = cur_box - dst_pos + src_pos;
             let cur_dst_pos = cur_box.min() - cur_block_box.min();
 
             // fill / modify buffer
-            src_block_buf_mat.copy_from(cur_dst_pos, src_mat, cur_src_box)?;
+            src_block_buf_mat.copy_from_order_agnostic(
+                cur_dst_pos,
+                src_mat,
+                cur_src_box,
+                &mut raw_disk_block_buf_mat,
+            )?;
 
             self.seek_block(cur_block_idx)?;
 
             // write in fortran order
-            let buffer_to_write = if src_block_buf_mat.data_in_c_order {
-                let dst_bbox = Box3::new(cur_dst_pos, cur_dst_pos + cur_src_box.width())?;
-                src_block_buf_mat.copy_as_fortran_order(&mut raw_disk_block_buf_mat, dst_bbox)?;
-                &raw_disk_block_buf_mat
-            } else {
-                &src_block_buf_mat
-            };
-            self.write_block(buffer_to_write.as_slice())?;
+            self.write_block(src_block_buf_mat.as_slice())?;
         }
 
         if self.header.block_type == BlockType::LZ4 || self.header.block_type == BlockType::LZ4HC {

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -177,12 +177,12 @@ impl File {
             if cur_box != cur_block_box {
                 // reuse existing data
                 self.seek_block(cur_block_idx)?;
-                let write_buffer = if src_block_buf_mat.data_in_c_order {
+                let buffer_to_initialize = if src_block_buf_mat.data_in_c_order {
                     &mut raw_disk_block_buf_mat
                 } else {
                     &mut src_block_buf_mat
                 };
-                self.read_block(write_buffer.as_mut_slice())?;
+                self.read_block(buffer_to_initialize.as_mut_slice())?;
             }
 
             let cur_src_box = cur_box - dst_pos + src_pos;

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -152,9 +152,9 @@ impl File {
         )?;
 
         // build second buffer
-        let mut raw_disk_block_buf = vec![0u8; self.header.block_size()];
-        let mut raw_disk_block_buf_mat = Mat::new(
-            raw_disk_block_buf.as_mut_slice(),
+        let mut c_to_fortran_buf = vec![0u8; self.header.block_size()];
+        let mut c_to_fortran_buf_mat = Mat::new(
+            c_to_fortran_buf.as_mut_slice(),
             Vec3::from(1u32 << block_len_log2),
             self.header.voxel_size as usize,
             self.header.voxel_type,
@@ -188,7 +188,7 @@ impl File {
                 cur_dst_pos,
                 src_mat,
                 cur_src_box,
-                &mut raw_disk_block_buf_mat,
+                &mut c_to_fortran_buf_mat,
             )?;
 
             self.seek_block(cur_block_idx)?;

--- a/rust/src/mat.rs
+++ b/rust/src/mat.rs
@@ -58,7 +58,7 @@ impl<'a> Mat<'a> {
         offset_vx as usize * self.voxel_size
     }
 
-    pub fn copy_as_fortran_order(&self, buffer: &mut Mat) -> Result<()> {
+    pub fn copy_as_fortran_order(&self, buffer: &mut Mat, src_bbox: Box3) -> Result<()> {
         if !self.data_in_c_order {
             return Err("Mat is already in fortran order");
         }
@@ -95,10 +95,12 @@ impl<'a> Mat<'a> {
         let src_ptr = self.data.as_ptr();
         let dst_ptr = buffer_data.as_mut_ptr();
 
+        let from = src_bbox.min();
+        let to = src_bbox.max();
         // Do continuous read in z. Last dim in Row-Major is continuous.
-        for x in 0usize..x_length {
-            for y in 0usize..y_length {
-                for z in 0usize..z_length {
+        for x in from.x as usize..to.x as usize {
+            for y in from.y as usize..to.y as usize {
+                for z in from.z as usize..to.z as usize {
                     let row_major_index = linearize(x, y, z, &row_major_stride);
                     let column_major_index = linearize(x, y, z, &column_major_stride);
                     unsafe {

--- a/rust/src/mat.rs
+++ b/rust/src/mat.rs
@@ -124,6 +124,10 @@ impl<'a> Mat<'a> {
         src_box: Box3,
         intermediate_buffer: &mut Mat,
     ) -> Result<()> {
+        if self.data_in_c_order {
+            return Err("copy_from_order_agnostic has to be called on a fortran order buffer.");
+        }
+
         if src.data_in_c_order {
             intermediate_buffer.copy_from(dst_pos, src, src_box)?;
             let dst_bbox = Box3::new(dst_pos, dst_pos + src_box.width())?;

--- a/rust/src/mat.rs
+++ b/rust/src/mat.rs
@@ -50,12 +50,15 @@ impl<'a> Mat<'a> {
     }
 
     fn offset(&self, pos: Vec3) -> usize {
+        // Early usize cast is necessary as overflows happen
         let offset_vx = if self.data_in_c_order {
-            pos.z + self.shape.z * (pos.y + self.shape.y * pos.x)
+            pos.z as usize
+                + self.shape.z as usize * (pos.y as usize + self.shape.y as usize * pos.x as usize)
         } else {
-            pos.x + self.shape.x * (pos.y + self.shape.y * pos.z)
+            pos.x as usize
+                + self.shape.x as usize * (pos.y as usize + self.shape.y as usize * pos.z as usize)
         };
-        offset_vx as usize * self.voxel_size
+        offset_vx * self.voxel_size
     }
 
     pub fn copy_as_fortran_order(&self, buffer: &mut Mat, src_bbox: Box3) -> Result<()> {

--- a/rust/src/mat.rs
+++ b/rust/src/mat.rs
@@ -114,6 +114,22 @@ impl<'a> Mat<'a> {
         Ok(())
     }
 
+    pub fn copy_from_order_agnostic(
+        &mut self,
+        dst_pos: Vec3,
+        src: &Mat,
+        src_box: Box3,
+        intermediate_buffer: &mut Mat,
+    ) -> Result<()> {
+        if src.data_in_c_order {
+            intermediate_buffer.copy_from(dst_pos, src, src_box)?;
+            let dst_bbox = Box3::new(dst_pos, dst_pos + src_box.width())?;
+            intermediate_buffer.copy_as_fortran_order(self, dst_bbox)
+        } else {
+            self.copy_from(dst_pos, src, src_box)
+        }
+    }
+
     pub fn copy_from(&mut self, dst_pos: Vec3, src: &Mat, src_box: Box3) -> Result<()> {
         // make sure that matrices are matching
         if self.voxel_size != src.voxel_size {


### PR DESCRIPTION
This PR implements a fix for the case that an incomplete row-major (c order) block is written.
When writing an incomplete block, the current implementation writes the data correctly but fills the rest of the block with scrambled data. The scrambled data origins from the block which is overwritten if it was empty, no harm is done.
The bug comes due to the fact that the existing data is first read in colum-major order into a buffer and the data to write (c order) is loaded in the very same buffer.

I added two tests to catch this bug and implemented a fix by filling the correct `block_buf`.


