### PR TITLE
use python version in wheel name

### DIFF
--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -92,7 +92,7 @@ jobs:
         pip install twine wheel
         cd python
         export PATH=$PATH:$HOME/.cargo/bin
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())")
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py3${{ matrix.python-version }}
         twine upload dist/*.whl
 
   build_win:
@@ -143,5 +143,5 @@ jobs:
       run: |
         pip install twine wheel
         cd python
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())")
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py3${{ matrix.python-version }}
         twine upload dist/*.whl

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -92,7 +92,7 @@ jobs:
         pip install twine wheel
         cd python
         export PATH=$PATH:$HOME/.cargo/bin
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py3${{ matrix.python-version }}
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
         twine upload dist/*.whl
 
   build_win:
@@ -143,5 +143,5 @@ jobs:
       run: |
         pip install twine wheel
         cd python
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py3${{ matrix.python-version }}
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
         twine upload dist/*.whl


### PR DESCRIPTION
The wheel upload fails if the name is already taken. The python version of the matrix build is now added to the name.