### PR TITLE
Fix lint warnings

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  println!("cargo:rustc-link-search={}", "../lz4/lib");
+  println!("cargo:rustc-link-search=../lz4/lib");
 }

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -8,7 +8,7 @@ pub struct Dataset {
     header: Header,
 }
 
-static HEADER_FILE_NAME: &'static str = "header.wkw";
+static HEADER_FILE_NAME: &str = "header.wkw";
 
 impl Dataset {
     pub fn new(root: &Path) -> Result<Dataset> {
@@ -21,7 +21,7 @@ impl Dataset {
 
         Ok(Dataset {
             root: root.to_owned(),
-            header: header,
+            header,
         })
     }
 

--- a/rust/src/file.rs
+++ b/rust/src/file.rs
@@ -23,8 +23,8 @@ impl File {
         };
 
         File {
-            file: file,
-            header: header,
+            file,
+            header,
             block_idx: None,
             disk_block_buf: block_buf,
         }
@@ -244,8 +244,7 @@ impl File {
             BlockType::LZ4 | BlockType::LZ4HC => {
                 let last_block_idx = self.header.file_vol() - 1;
                 let jump_table = self.header.jump_table.as_ref().unwrap();
-                let size = jump_table[last_block_idx as usize];
-                size
+                jump_table[last_block_idx as usize]
             }
         };
 
@@ -331,7 +330,7 @@ impl File {
         // write data
         self.file
             .write_all(&buf_lz4[..len_lz4])
-            .or(Err(String::from("Could not write LZ4 block")))?;
+            .or(Err("Could not write LZ4 block"))?;
 
         // update jump table
         let jump_entry = self
@@ -357,7 +356,7 @@ impl File {
         // read compressed block
         self.file
             .read_exact(buf_lz4)
-            .or(Err(String::from("Error while reading LZ4 block")))?;
+            .or(Err("Error while reading LZ4 block"))?;
 
         // decompress block
         let byte_written = lz4::decompress_safe(buf_lz4, buf)?;

--- a/rust/src/header.rs
+++ b/rust/src/header.rs
@@ -192,7 +192,7 @@ impl Header {
                 if block_idx == 0 {
                     self.data_offset
                 } else {
-                    let ref jump_table = *self.jump_table.as_ref().unwrap();
+                    let jump_table = &*self.jump_table.as_ref().unwrap();
                     jump_table[block_idx as usize - 1]
                 }
             }
@@ -205,7 +205,7 @@ impl Header {
         match self.block_type {
             BlockType::Raw => Ok(self.block_size() as usize),
             BlockType::LZ4 | BlockType::LZ4HC => {
-                let ref jump_table = *self.jump_table.as_ref().unwrap();
+                let jump_table = &*self.jump_table.as_ref().unwrap();
 
                 if block_idx == 0 {
                     let block_size = jump_table[0] - self.data_offset;
@@ -247,7 +247,7 @@ impl Header {
     fn from_bytes(buf: [u8; 16]) -> Result<Header> {
         let raw: HeaderRaw = unsafe { mem::transmute(buf) };
 
-        if &raw.magic != "WKW".as_bytes() {
+        if &raw.magic != b"WKW" {
             return Err(format!("Sequence of magic bytes {:?} is invalid", &raw.magic));
         }
 
@@ -281,10 +281,10 @@ impl Header {
 
         Ok(Header {
             version: raw.version,
-            block_len_log2: block_len_log2,
-            file_len_log2: file_len_log2,
-            block_type: block_type,
-            voxel_type: voxel_type,
+            block_len_log2,
+            file_len_log2,
+            block_type,
+            voxel_type,
             voxel_size: raw.voxel_size,
             data_offset: raw.data_offset,
             jump_table: None,
@@ -297,7 +297,7 @@ impl Header {
         let mut raw = HeaderRaw {
             magic: [0u8; 3],
             version: self.version,
-            per_dim_log2: per_dim_log2,
+            per_dim_log2,
             block_type: 1u8 + self.block_type as u8,
             voxel_type: 1u8 + self.voxel_type as u8,
             voxel_size: self.voxel_size,
@@ -305,7 +305,7 @@ impl Header {
         };
 
         // set magic bytes
-        raw.magic.copy_from_slice("WKW".as_bytes());
+        raw.magic.copy_from_slice(b"WKW");
 
         // convert to bytes
         unsafe { mem::transmute::<HeaderRaw, [u8; 16]>(raw) }

--- a/rust/src/mat.rs
+++ b/rust/src/mat.rs
@@ -31,11 +31,11 @@ impl<'a> Mat<'a> {
         }
 
         Ok(Mat {
-            data: data,
-            shape: shape,
-            voxel_size: voxel_size,
-            voxel_type: voxel_type,
-            data_in_c_order: data_in_c_order,
+            data,
+            shape,
+            voxel_size,
+            voxel_type,
+            data_in_c_order,
         })
     }
 
@@ -92,7 +92,7 @@ impl<'a> Mat<'a> {
             x_length * y_length * self.voxel_size,
         ];
 
-        fn linearize(x: usize, y: usize, z: usize, stride: &Vec<usize>) -> isize {
+        fn linearize(x: usize, y: usize, z: usize, stride: &[usize]) -> isize {
             (x * stride[0] + y * stride[1] + z * stride[2]) as isize
         }
         let src_ptr = self.data.as_ptr();
@@ -186,8 +186,8 @@ impl<'a> Mat<'a> {
             * self.voxel_size) as isize;
 
         unsafe {
-            let mut src_ptr = src.data.as_ptr().offset(src.offset(src_box.min()) as isize);
-            let mut dst_ptr = self.data.as_mut_ptr().offset(self.offset(dst_pos) as isize);
+            let mut src_ptr = src.data.as_ptr().add(src.offset(src_box.min()));
+            let mut dst_ptr = self.data.as_mut_ptr().add(self.offset(dst_pos));
 
             for _ in 0..unified_length.z {
                 let mut src_ptr_cur = src_ptr;

--- a/rust/src/morton.rs
+++ b/rust/src/morton.rs
@@ -30,7 +30,7 @@ fn unshuffle(z: u64) -> u64 {
 impl<'a> From<&'a Vec3> for Morton {
     fn from(vec: &'a Vec3) -> Morton {
         Morton(
-            (shuffle(vec.x as u64) << 0)
+            (shuffle(vec.x as u64))
                 | (shuffle(vec.y as u64) << 1)
                 | (shuffle(vec.z as u64) << 2),
         )
@@ -40,7 +40,7 @@ impl<'a> From<&'a Vec3> for Morton {
 impl From<Morton> for Vec3 {
     fn from(idx: Morton) -> Vec3 {
         Vec3 {
-            x: unshuffle(idx.0 >> 0) as u32,
+            x: unshuffle(idx.0) as u32,
             y: unshuffle(idx.0 >> 1) as u32,
             z: unshuffle(idx.0 >> 2) as u32,
         }
@@ -71,8 +71,8 @@ impl Iter {
         Ok(Iter {
             idx: 0,
             end: 0,
-            log2: log2,
-            bbox: bbox,
+            log2,
+            bbox,
         })
     }
 
@@ -97,10 +97,10 @@ impl Iter {
             } else if !bbox_inter.is_empty() {
                 // need to refine
                 debug_assert!(cur_log2 > 0);
-                cur_log2 = cur_log2 - 1;
+                cur_log2 -= 1;
             } else {
                 // skip cube
-                cur_idx = cur_idx + numel;
+                cur_idx += numel;
                 cur_log2 = cur_idx.trailing_zeros() / 3;
             }
         }
@@ -125,37 +125,37 @@ impl Iterator for Iter {
         }
 
         // advance
-        self.idx = self.idx + 1;
+        self.idx += 1;
         Some(self.idx as u64 - 1)
     }
 }
 
 #[test]
 fn test_encoding() {
-    assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 0 }) == Morton::from(0 as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 0, z: 0 }) == Morton::from(1 as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 1, z: 0 }) == Morton::from(2 as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 1, z: 0 }) == Morton::from(3 as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 1 }) == Morton::from(4 as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 0, z: 1 }) == Morton::from(5 as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 1, z: 1 }) == Morton::from(6 as u64));
-    assert!(Morton::from(&Vec3 { x: 1, y: 1, z: 1 }) == Morton::from(7 as u64));
-    assert!(Morton::from(&Vec3 { x: 2, y: 0, z: 0 }) == Morton::from(8 as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 2, z: 0 }) == Morton::from(16 as u64));
-    assert!(Morton::from(&Vec3 { x: 0, y: 0, z: 2 }) == Morton::from(32 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 0, y: 0, z: 0 }), Morton::from(0 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 1, y: 0, z: 0 }), Morton::from(1 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 0, y: 1, z: 0 }), Morton::from(2 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 1, y: 1, z: 0 }), Morton::from(3 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 0, y: 0, z: 1 }), Morton::from(4 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 1, y: 0, z: 1 }), Morton::from(5 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 0, y: 1, z: 1 }), Morton::from(6 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 1, y: 1, z: 1 }), Morton::from(7 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 2, y: 0, z: 0 }), Morton::from(8 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 0, y: 2, z: 0 }), Morton::from(16 as u64));
+    assert_eq!(Morton::from(&Vec3 { x: 0, y: 0, z: 2 }), Morton::from(32 as u64));
 }
 
 #[test]
 fn test_decoding() {
-    assert!(Vec3 { x: 0, y: 0, z: 0 } == Vec3::from(Morton::from(0 as u64)));
-    assert!(Vec3 { x: 1, y: 0, z: 0 } == Vec3::from(Morton::from(1 as u64)));
-    assert!(Vec3 { x: 0, y: 1, z: 0 } == Vec3::from(Morton::from(2 as u64)));
-    assert!(Vec3 { x: 1, y: 1, z: 0 } == Vec3::from(Morton::from(3 as u64)));
-    assert!(Vec3 { x: 0, y: 0, z: 1 } == Vec3::from(Morton::from(4 as u64)));
-    assert!(Vec3 { x: 1, y: 0, z: 1 } == Vec3::from(Morton::from(5 as u64)));
-    assert!(Vec3 { x: 0, y: 1, z: 1 } == Vec3::from(Morton::from(6 as u64)));
-    assert!(Vec3 { x: 1, y: 1, z: 1 } == Vec3::from(Morton::from(7 as u64)));
-    assert!(Vec3 { x: 2, y: 0, z: 0 } == Vec3::from(Morton::from(8 as u64)));
-    assert!(Vec3 { x: 0, y: 2, z: 0 } == Vec3::from(Morton::from(16 as u64)));
-    assert!(Vec3 { x: 0, y: 0, z: 2 } == Vec3::from(Morton::from(32 as u64)));
+    assert_eq!(Vec3 { x: 0, y: 0, z: 0 }, Vec3::from(Morton::from(0 as u64)));
+    assert_eq!(Vec3 { x: 1, y: 0, z: 0 }, Vec3::from(Morton::from(1 as u64)));
+    assert_eq!(Vec3 { x: 0, y: 1, z: 0 }, Vec3::from(Morton::from(2 as u64)));
+    assert_eq!(Vec3 { x: 1, y: 1, z: 0 }, Vec3::from(Morton::from(3 as u64)));
+    assert_eq!(Vec3 { x: 0, y: 0, z: 1 }, Vec3::from(Morton::from(4 as u64)));
+    assert_eq!(Vec3 { x: 1, y: 0, z: 1 }, Vec3::from(Morton::from(5 as u64)));
+    assert_eq!(Vec3 { x: 0, y: 1, z: 1 }, Vec3::from(Morton::from(6 as u64)));
+    assert_eq!(Vec3 { x: 1, y: 1, z: 1 }, Vec3::from(Morton::from(7 as u64)));
+    assert_eq!(Vec3 { x: 2, y: 0, z: 0 }, Vec3::from(Morton::from(8 as u64)));
+    assert_eq!(Vec3 { x: 0, y: 2, z: 0 }, Vec3::from(Morton::from(16 as u64)));
+    assert_eq!(Vec3 { x: 0, y: 0, z: 2 }, Vec3::from(Morton::from(32 as u64)));
 }

--- a/rust/src/vec.rs
+++ b/rust/src/vec.rs
@@ -17,7 +17,7 @@ pub struct Box3 {
 impl Box3 {
     pub fn new(min: Vec3, max: Vec3) -> Result<Box3> {
         match min < (max + 1) {
-            true => Ok(Box3 { min: min, max: max }),
+            true => Ok(Box3 { min, max }),
             false => Err(String::from("Minimum and maximum are in conflict")),
         }
     }
@@ -48,7 +48,7 @@ impl From<Vec3> for Box3 {
     fn from(max: Vec3) -> Box3 {
         Box3 {
             min: Vec3::from(0u32),
-            max: max,
+            max,
         }
     }
 }


### PR DESCRIPTION
`cargo clippy` reported around 40 lint warnings before. The number of warnings are now reduced to 7. These 7 warnings can be categorized into two groups:
- **negated comparison operators on partially ordered types** (e.g. `if !(src_box.max() < (src.shape + 1))`)
    - This could be resolved with a `match`-statement, but I would argue that this is not necessary here because it is a simple comparison of `Vec3`.
- **use of `or` followed by a function call** (e.g. `.or(Err(format!("Could not create parent directory {:?}", parent)))?;`)
    - This warning is raised because the function is always called. Calling a function in `or` could have side effects and allocates an object
    - I would argue that this is not a problem, because the `format`-function does not have any side effects