### PR TITLE
Scala: Prevent reading only parts of InputStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,24 +117,6 @@ only semantic.
 
 Decompression must produce valid raw blocks.
 
-## Usage
-
-### Scala Release Process
-
-#### Local Testing
-To test changes locally, run `sbt publishLocal`. The [current version] should already be bumped and marked as `SNAPSHOT`. Then adapt the dependency to webknossos-wrap to this version.
-
-#### Releasing a version to maven
-Specify the sonatype credentials in `~/.sbt/<sbt version>/sonatype.sbt`:
-```
-credentials += Credentials("Sonatype Nexus Repository Manager",
-       "oss.sonatype.org",
-       "<user>",
-       "<password>")
-```
-
-Then run `sbt release`. This increments the version automatically, publishes the build and adds git commits and tags. Push the git changes via `git push --follow-tags`.
-
 ## Credits
 * [Max Planck Institute for Brain Research](https://brain.mpg.de/)
   - Alessandro Motta

--- a/scala/README.md
+++ b/scala/README.md
@@ -6,17 +6,23 @@ Is a library for loading data stored on disk in the webKnossos wrap file format.
 ## How to build the library
 
 #### Development
-During development, the library should be published locally using
-
-	sbt publish-local
-
-The packages get placed in .ivy2/local/com/scalableminds. To reference the build in another project you need to specify the version, which is contained in the `version` file, in the build file of the dependent project.
+To test changes locally, run `sbt publishLocal`. The [current version] should already be bumped and marked as `SNAPSHOT`. Then adapt the dependency to webknossos-wrap to this version.
 
 #### Release
-To release a new version of the libraries to our internal maven repository, make sure to commit all changes before starting the release procedure. You can use the release script to publish the library
 
-	release 0.3.5
+- Specify the sonatype credentials in `~/.sbt/<sbt version>/sonatype.sbt`:
+```
+credentials += Credentials("Sonatype Nexus Repository Manager",
+       "oss.sonatype.org",
+       "<user>",
+       "<password>")
+```
 
-This will build the library, publish it, create a github tag and pushes this tag to the origin repository.
+- Make sure you have [sbt-pgp](https://github.com/sbt/sbt-pgp) up and running, and have an active and published gpg key.
+- Make sure all changes are committed locally
+- Run `sbt release`. This increments the version automatically, publishes the build to a temporary staging repository and adds git commits and tags.
+- Log in to [Sonatype Nexus](https://oss.sonatype.org) and close and release the newly created Staging Repository, compare [this guide](https://central.sonatype.org/pages/releasing-the-deployment.html).
+- After some delay (10min to 2h) the package should be synced to maven
+- If all is successful, push the git changes via `git push --follow-tags`.
 
 **Never release a version twice. This screws up all caches and may lead to build errors in the projects depending on the library!**

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -55,6 +55,7 @@ libraryDependencies ++= Seq(
   "net.liftweb" % "lift-common_2.10" % "2.6-M3",
   "net.liftweb" % "lift-util_2.10" % "3.0-M1",
   "org.apache.commons" % "commons-lang3" % "3.1",
+  "commons-io" % "commons-io" % "2.4",
   "org.apache.logging.log4j" % "log4j-api" % "2.0-beta9",
   "org.apache.logging.log4j" % "log4j-core" % "2.0-beta9"
 )

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -44,6 +44,16 @@ scmInfo := Some(ScmInfo(
   url("https://github.com/scalableminds/webknossos-wrap"),
   "https://github.com/scalableminds/webknossos-wrap.git"))
 
+pomExtra := (
+  <developers>
+    <developer>
+      <id>fm3</id>
+      <name>Florian M</name>
+      <url>https://github.com/fm3</url>
+    </developer>
+  </developers>
+)
+
 libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "21.0",
   "com.jsuereth" %% "scala-arm" % "2.0",

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -38,6 +38,8 @@ description := "A small library to load webknossos-wrap encoded files."
 
 homepage := Some(url("https://github.com/scalableminds/webknossos-wrap"))
 
+licenses := Seq("AGPL-3.0" -> url("https://www.gnu.org/licenses/agpl-3.0.html"))
+
 scmInfo := Some(ScmInfo(
   url("https://github.com/scalableminds/webknossos-wrap"),
   "https://github.com/scalableminds/webknossos-wrap.git"))
@@ -56,6 +58,8 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-api" % "2.0-beta9",
   "org.apache.logging.log4j" % "log4j-core" % "2.0-beta9"
 )
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
 val root = (project in file("."))
   .enablePlugins(BuildInfoPlugin)

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -21,12 +21,9 @@ publishArtifact in Test := false
 pomIncludeRepository := { _ => false }
 
 publishTo := {
-  val path =
-    if (isSnapshot.value)
-      "snapshots"
-    else
-      "releases"
-  Some("scm.io nexus repo" at "https://oss.sonatype.org/content/repositories/" + path)
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
 organization := "com.scalableminds"

--- a/scala/src/main/scala/com/scalableminds/webknossos/wrap/WKWFile.scala
+++ b/scala/src/main/scala/com/scalableminds/webknossos/wrap/WKWFile.scala
@@ -1,12 +1,10 @@
-/*
- * Copyright (C) 2011-2017 scalableminds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.wrap
 
 import java.io._
 import java.nio.channels.FileChannel
 import java.nio.file.{Files, Paths, StandardCopyOption}
 
+import org.apache.commons.io.IOUtils
 import com.google.common.io.{LittleEndianDataInputStream => DataInputStream}
 import com.newrelic.api.agent.NewRelic
 import com.scalableminds.webknossos.wrap.util.ExtendedTypes._
@@ -303,8 +301,7 @@ object WKWFile extends WKWCompressionHelper {
         header <- WKWHeader(dataStream, true)
       } yield {
         val blockIterator = header.blockLengths.flatMap { blockLength =>
-          val data = Array.ofDim[Byte](blockLength)
-          dataStream.read(data)
+          val data: Array[Byte] = IOUtils.toByteArray(dataStream, blockLength)
           if (header.isCompressed) decompressBlock(header.blockType, header.numBytesPerBlock)(data) else Full(data)
         }
         f(header, blockIterator)

--- a/scala/src/main/scala/com/scalableminds/webknossos/wrap/WKWHeader.scala
+++ b/scala/src/main/scala/com/scalableminds/webknossos/wrap/WKWHeader.scala
@@ -1,10 +1,8 @@
-/*
- * Copyright (C) 2011-2017 scalableminds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.wrap
 
 import com.google.common.io.{LittleEndianDataInputStream => DataInputStream}
 import com.scalableminds.webknossos.wrap.util.{BoxImplicits, ResourceBox}
+import org.apache.commons.io.IOUtils
 import java.io._
 import java.nio.{ByteBuffer, ByteOrder}
 
@@ -120,8 +118,7 @@ object WKWHeader extends BoxImplicits {
   val currentVersion = 1
 
   def apply(dataStream: DataInputStream, readJumpTable: Boolean): Box[WKWHeader] = {
-    val magicByteBuffer: Array[Byte] = Array.ofDim[Byte](magicBytes.length)
-    dataStream.read(magicByteBuffer, 0, magicBytes.length)
+    val magicByteBuffer: Array[Byte] = IOUtils.toByteArray(dataStream, magicBytes.length)
     val version = dataStream.readUnsignedByte()
     val sideLengths = dataStream.readUnsignedByte()
     val numBlocksPerCubeDimension = 1 << (sideLengths >>> 4) // fileSideLength [higher nibble]

--- a/scala/src/main/scala/com/scalableminds/webknossos/wrap/util/BoxImplicits.scala
+++ b/scala/src/main/scala/com/scalableminds/webknossos/wrap/util/BoxImplicits.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.wrap.util
 
 import net.liftweb.common.{Box, Empty, Full}

--- a/scala/src/main/scala/com/scalableminds/webknossos/wrap/util/ExtendedTypes.scala
+++ b/scala/src/main/scala/com/scalableminds/webknossos/wrap/util/ExtendedTypes.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.wrap.util
 
 import java.io.RandomAccessFile

--- a/scala/src/main/scala/com/scalableminds/webknossos/wrap/util/ResourceBox.scala
+++ b/scala/src/main/scala/com/scalableminds/webknossos/wrap/util/ResourceBox.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalableminds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.wrap.util
 
 import net.liftweb.common.{Box, Failure}

--- a/scala/version.sbt
+++ b/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.9"
+version in ThisBuild := "1.1.10-SNAPSHOT"

--- a/scala/version.sbt
+++ b/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.8-SNAPSHOT"
+version in ThisBuild := "1.1.8"

--- a/scala/version.sbt
+++ b/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.9-SNAPSHOT"
+version in ThisBuild := "1.1.9"

--- a/scala/version.sbt
+++ b/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.8"
+version in ThisBuild := "1.1.9-SNAPSHOT"


### PR DESCRIPTION
Replacing `InputStream.read()` with appache commons’ `IOUtils.toByteArray` as the former reads *some number* of bytes (compare [java docs](https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read())) and that number occasionally was less than one bucket, resulting in missing data.