### PR TITLE
MATLAB: Make `wkwBoundingBox` robust and platform agnostic

### DIFF
--- a/matlab/wkwBoundingBox.m
+++ b/matlab/wkwBoundingBox.m
@@ -27,12 +27,19 @@ function box = wkwBoundingBox(wkwDir)
         fullfile(f.folder, f.name), ...
         wkwFiles, 'UniformOutput', false);
     
-    pattern = ['z(\d+)', filesep, 'y(\d+)', filesep, 'x(\d+)'];
-    coords = regexp(wkwFiles, pattern, 'tokens', 'once');
-    
-    coords = flip(cat(1, coords{:}), 2);
-    coords = cellfun(@str2double, coords);
+    coords = cell2mat(cellfun(@getCoords, ...
+        wkwFiles(:), 'UniformOutput', false));
     
     box = [min(coords, [], 1)', max(coords, [], 1)'];
     box = (box + [0, 1]) * voxelsPerFileDim + [1, 0];
+end
+
+function coords = getCoords(path)
+    coords = nan(1, 3);
+    
+    for dim = 1:numel(coords)
+       [path, coord] = fileparts(path);
+        assert(coord(1) == char(char('x') + (dim - 1)));
+        coords(dim) = str2double(coord(2:end));
+    end
 end


### PR DESCRIPTION
This commit makes MATLAB's `wkwBoundingBox` platform agnostic and fixes #62. 

Pull request #37 by @mgschm addresses the same issue. It does so by changing the regular expression in a platform-dependent manner. Here, a more robust alternative is proposed:  We now use MATLAB's built-in `fileparts` function instead of regular expressions. This function also handles any cross-platform differences.

@sahilloomba @mgschm Could you please test this on Windows?