### PR TITLE
Drop python3.6 in CI and add 3.9

### DIFF
--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build_lin:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: Build testing docker container
@@ -31,7 +31,7 @@ jobs:
           testing \
           bash -c "
             \$PYBIN/python setup.py install
-            \$PYBIN/python setup.py bdist_wheel -p manylinux2010_x86_64"
+            \$PYBIN/python setup.py bdist_wheel -p manylinux2014_x86_64"
     - name: Test
       run: |
         docker run \
@@ -52,9 +52,9 @@ jobs:
           -v$(pwd):/app \
           testing \
           bash -c "
-            for PYBIN in /opt/python/*/bin; do
+            for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39}/bin; do
               echo --> \$PYBIN
-              \$PYBIN/pip install /app/python/dist/wkw-*-py3-none-manylinux2010_x86_64.whl
+              \$PYBIN/pip install /app/python/dist/wkw-*-py3-none-manylinux2014_x86_64.whl
               \$PYBIN/python -c 'import wkw; print(wkw.Dataset)'
             done"
     - name: Publish
@@ -74,7 +74,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -124,7 +124,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -53,7 +53,7 @@ jobs:
           testing \
           bash -c "
             for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39}/bin; do
-              echo --> \$PYBIN
+              echo '-->' \$PYBIN
               \$PYBIN/pip install /app/python/dist/wkw-*-py3-none-manylinux2014_x86_64.whl
               \$PYBIN/python -c 'import wkw; print(wkw.Dataset)'
             done"

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,9 +1,9 @@
-FROM quay.io/pypa/manylinux2010_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    PYBIN=/opt/python/cp36-cp36m/bin
+    PYBIN=/opt/python/cp37-cp37m/bin
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \


### PR DESCRIPTION
Also fixes the current tests, because the latest numpy (1.20) dropped py3.6 support.