### PR TITLE
Add universal2 wheels for the mac platform

### DIFF
--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -81,6 +81,8 @@ jobs:
       run: |
         brew install rustup-init
         rustup-init -y
+        rustup target add aarch64-apple-darwin
+        rustup target add x86_64-apple-darwin
     - name: Build
       run: |
         cd python
@@ -101,7 +103,7 @@ jobs:
         pip install twine wheel
         cd python
         export PATH=$PATH:$HOME/.cargo/bin
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform().replace('x86_64', 'universal2'))") --python-tag py${{ matrix.python-version }}
         twine upload dist/*.whl
 
   build_win:

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -65,7 +65,7 @@ jobs:
            bash -c "\$PYBIN/python setup.py sdist bdist_wheel -p manylinux1_x86_64 && \$PYBIN/twine upload dist/*.whl dist/*.tar.gz"
 
   build_mac:
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       max-parallel: 4
       matrix:

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,40 @@ class BuildPyCommand(build_py):
 
         # building C library
         subprocess.call(["cargo", "clean"], cwd=c_dir)
-        subprocess.call(["cargo", "build", "--release"], cwd=c_dir)
+        if platform.system() == "Darwin":
+            subprocess.call(
+                ["cargo", "build", "--target=aarch64-apple-darwin", "--release"],
+                cwd=c_dir,
+            )
+            subprocess.call(
+                ["cargo", "build", "--target=x86_64-apple-darwin", "--release"],
+                cwd=c_dir,
+            )
+            subprocess.call(
+                [
+                    "lipo",
+                    "-create",
+                    os.path.join(
+                        c_dir,
+                        "target",
+                        "aarch64-apple-darwin",
+                        "release",
+                        "libwkw.dylib",
+                    ),
+                    os.path.join(
+                        c_dir,
+                        "target",
+                        "x86_64-apple-darwin",
+                        "release",
+                        "libwkw.dylib",
+                    ),
+                    "-output",
+                    os.path.join(c_dir, "target", "release", "libwkw.dylib"),
+                ],
+                cwd=c_dir,
+            )
+        else:
+            subprocess.call(["cargo", "build", "--release"], cwd=c_dir)
 
         lib_name_platform = {
             "Linux": "libwkw.so",

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,12 +17,14 @@ class BuildPyCommand(build_py):
         # building C library
         subprocess.call(["cargo", "clean"], cwd=c_dir)
         if platform.system() == "Darwin":
-            subprocess.call(
-                ["cargo", "build", "--target=aarch64-apple-darwin", "--release"],
-                cwd=c_dir,
-            )
+            print("x86_64-apple-darwin compilation")
             subprocess.call(
                 ["cargo", "build", "--target=x86_64-apple-darwin", "--release"],
+                cwd=c_dir,
+            )
+            print("aarch64-apple-darwin compilation")
+            subprocess.call(
+                ["cargo", "build", "--target=aarch64-apple-darwin", "--release"],
                 cwd=c_dir,
             )
             subprocess.call(


### PR DESCRIPTION
This PR adds Apple silicon support to the pre-compiled wheels by providing a universal2 (x86_64 + arm64) dylib. The universal2 dylib is assembled by compiling both libraries individually and combining them with `lipo` (a standard xcode tool).
The new wheel will be distributed through pypi, as regular.

### Testing
First, install the rust toolchains:
```
rustup target add aarch64-apple-darwin
rustup target add x86_64-apple-darwin
```

Testing the x86_64 version was easy with a conda env (and is also performed by the CI). For the arm64 version, I used the homebrew-shipped python:
```
/opt/homebrew/bin/python3.9 -c "import distutils.util; print(distutils.util.get_platform())" # verify we are running a arm64-version
/opt/homebrew/bin/python3.9 -m pip install -r requirements.txt
/opt/homebrew/bin/python3.9 setup.py install
/opt/homebrew/bin/python3.9 -c "import wkw"
/opt/homebrew/bin/python3.9 -m pip install pytest
/opt/homebrew/bin/python3.9 -m pytest tests
```