### PR TITLE
Scala: Remove logging dependencies log4j and scalalogging

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -57,14 +57,11 @@ pomExtra := (
 libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "21.0",
   "com.jsuereth" %% "scala-arm" % "2.0",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
   "net.jpountz.lz4" % "lz4" % "1.3.0",
   "net.liftweb" % "lift-common_2.10" % "2.6-M3",
   "net.liftweb" % "lift-util_2.10" % "3.0-M1",
   "org.apache.commons" % "commons-lang3" % "3.1",
   "commons-io" % "commons-io" % "2.9.0",
-  "org.apache.logging.log4j" % "log4j-api" % "2.15.0",
-  "org.apache.logging.log4j" % "log4j-core" % "2.15.0"
 )
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value

--- a/scala/version.sbt
+++ b/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.15-SNAPSHOT"
+version in ThisBuild := "1.1.15"

--- a/scala/version.sbt
+++ b/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.15"
+version in ThisBuild := "1.1.16-SNAPSHOT"


### PR DESCRIPTION
webknossos-wrap is not actually logging anything. I guess this was added for development only.
Should we want to develop this further and log things again, we should re-add the dependencies with then-current versions.