### PR TITLE
Tested support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -45,12 +45,14 @@ jobs:
       run: |
         docker run \
           -v$(pwd):/app \
+          -w/app/python \
           testing \
           bash -c "
             for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39,cp310-cp310,cp311-cp311}/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install /app/python/dist/wkw-*-py3-none-manylinux2014_x86_64.whl
               \$PYBIN/python -c 'import wkw; print(wkw.Dataset)'
+              \$PYBIN/pytest tests -v
             done"
     - name: Publish
       if: startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -88,7 +88,8 @@ jobs:
       run: |
         cd python
         export PATH=$PATH:$HOME/.cargo/bin
-        python setup.py install
+        python setup.py bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform().replace('x86_64', 'universal2'))")
+        pip install dist/*.whl
     - name: Test
       run: |
         cd python
@@ -103,8 +104,9 @@ jobs:
       run: |
         pip install twine wheel
         cd python
+        rm -rf dist
         export PATH=$PATH:$HOME/.cargo/bin
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform().replace('x86_64', 'universal2'))") --python-tag py${{ matrix.python-version }}
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform().replace('x86_64', 'universal2'))")
         twine upload dist/*.whl
 
   build_win:
@@ -124,7 +126,8 @@ jobs:
       shell: bash
       run: |
         cd python
-        python setup.py install
+        python setup.py bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())")
+        pip install dist/*.whl
     - name: Test
       shell: bash
       run: |
@@ -146,5 +149,6 @@ jobs:
       run: |
         pip install twine wheel
         cd python
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
+        rm -rf dist
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())")
         twine upload dist/*.whl

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -47,7 +47,7 @@ jobs:
           -v$(pwd):/app \
           testing \
           bash -c "
-            for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39}/bin; do
+            for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39,cp310-cp310,cp311-cp311}/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install /app/python/dist/wkw-*-py3-none-manylinux2014_x86_64.whl
               \$PYBIN/python -c 'import wkw; print(wkw.Dataset)'
@@ -68,7 +68,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -110,7 +110,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -88,6 +88,7 @@ jobs:
       run: |
         cd python
         export PATH=$PATH:$HOME/.cargo/bin
+        pip install twine wheel
         python setup.py bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform().replace('x86_64', 'universal2'))")
         pip install dist/*.whl
     - name: Test
@@ -102,7 +103,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        pip install twine wheel
         cd python
         rm -rf dist
         export PATH=$PATH:$HOME/.cargo/bin
@@ -126,6 +126,7 @@ jobs:
       shell: bash
       run: |
         cd python
+        pip install twine wheel
         python setup.py bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())")
         pip install dist/*.whl
     - name: Test
@@ -147,7 +148,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        pip install twine wheel
         cd python
         rm -rf dist
         python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())")

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -13,10 +13,14 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y; \
     cargo --version; \
     rustc --version;
 
-RUN $PYBIN/pip install \
-  numpy \
-  cffi \
-  setuptools \
-  pytest \
-  twine \
-  black==22.3.0
+RUN for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39,cp310-cp310,cp311-cp311}/bin; do; \
+  echo "--> $PYBIN"; \
+  $PYBIN/pip install \
+    numpy \
+    cffi \
+    setuptools \
+    pytest \
+    twine \
+    black==22.3.0; \
+  done
+

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -13,7 +13,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y; \
     cargo --version; \
     rustc --version;
 
-RUN for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39,cp310-cp310,cp311-cp311}/bin; do; \
+RUN for PYBIN in /opt/python/{cp37-cp37m,cp38-cp38,cp39-cp39,cp310-cp310,cp311-cp311}/bin; do \
   echo "--> $PYBIN"; \
   $PYBIN/pip install \
     numpy \


### PR DESCRIPTION
- Adds tests for Python 3.10 and 3.11
- Since python-wkw uses ffi to access the wkw-library, we don't depend on the Python ABI. Therefore, we can ship a single `py3` wheel per platform